### PR TITLE
Implement unit testing and CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+# Scala setup.
+language: scala
+scala:
+  - "2.12.8"
+jdk:
+  - openjdk8
+
+# Cache Maven and SBT packages so we don't need to keep reinstalling them.
+cache:
+  directories:
+  - $HOME/.m2
+  - $HOME/.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,9 @@ scalacOptions in Test ++= Seq("-Yrangepos")
 // Set up the main class.
 mainClass in (Compile, run) := Some("org.renci.shacli.ShacliApp")
 
+// Set up testing.
+testFrameworks += new TestFramework("utest.runner.Framework")
+
 libraryDependencies ++= {
   Seq(
     // Logging
@@ -22,6 +25,9 @@ libraryDependencies ++= {
     "org.topbraid"                % "shacl"                   % "1.3.0",
 
     // Add support for CSV
-    "com.github.tototoshi"        %% "scala-csv"              % "1.3.6"
+    "com.github.tototoshi"        %% "scala-csv"              % "1.3.6",
+
+    // Testing
+    "com.lihaoyi"                 %% "utest"                  % "0.7.1" % "test"
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,9 @@ scalacOptions in Test ++= Seq("-Yrangepos")
 // Set up the main class.
 mainClass in (Compile, run) := Some("org.renci.shacli.ShacliApp")
 
+// Fork when running.
+fork in run := true
+
 // Set up testing.
 testFrameworks += new TestFramework("utest.runner.Framework")
 

--- a/src/main/scala/org/renci/shacli/ShacliApp.scala
+++ b/src/main/scala/org/renci/shacli/ShacliApp.scala
@@ -96,6 +96,8 @@ object ValidationErrorGenerator {
  * Command line configuration for Validate.
  */
 class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
+  val version = getClass.getPackage.getImplementationVersion
+  version("SHACLI: A SHACLI CLI v" + version)
   val shapes = trailArg[File](
     descr = "Shapes file to validate (in Turtle)"
   )

--- a/src/test/resources/test1_data.ttl
+++ b/src/test/resources/test1_data.ttl
@@ -1,0 +1,13 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+@prefix example: <http://example.org/> .
+
+# Some dogs for testing.
+example:Shadow a example:Dog ;
+  foaf:name "Shadow" ;
+  foaf:name "Shadow The Sheepdog" ;
+  foaf:age 1
+.

--- a/src/test/resources/test1_shapes.ttl
+++ b/src/test/resources/test1_shapes.ttl
@@ -1,0 +1,21 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+@prefix example: <http://example.org/> .
+
+# A simple SHACL example.
+
+example:Dog a rdfs:Class ;
+  rdfs:label "Dogs"@en
+.
+
+example:DogShape a sh:NodeShape ;
+  sh:targetClass example:Dog ;
+  sh:property [
+    sh:path foaf:name ;
+    sh:minCount 1 ;
+    sh:maxCount 1
+  ]
+.

--- a/src/test/scala/org/renci/shacli/ShacliAppTest.scala
+++ b/src/test/scala/org/renci/shacli/ShacliAppTest.scala
@@ -1,0 +1,64 @@
+package org.renci.shacli
+
+import java.io.{File, FileWriter, PrintWriter}
+import java.time.ZonedDateTime
+import java.util.Calendar
+
+import java.io.{File, FileInputStream, IOException, InputStream, ByteArrayOutputStream, StringWriter}
+
+import sys.process._
+
+import org.topbraid.shacl.validation._
+import org.apache.jena.ontology.OntDocumentManager
+import org.apache.jena.ontology.OntModel
+import org.apache.jena.ontology.OntModelSpec
+import org.apache.jena.rdf.model.{Model, ModelFactory, Resource, RDFNode, RDFList, SimpleSelector}
+import org.apache.jena.util.FileUtils
+import org.topbraid.jenax.util.JenaUtil
+import org.topbraid.jenax.util.SystemTriples
+import org.topbraid.shacl.compact.SHACLC
+import org.topbraid.shacl.util.SHACLSystemModel
+import org.topbraid.shacl.vocabulary.DASH
+import org.topbraid.shacl.vocabulary.SH
+import org.topbraid.shacl.vocabulary.TOSH
+import org.apache.jena.vocabulary.RDF
+import org.apache.jena.vocabulary.RDFS
+import org.rogach.scallop._
+
+import com.typesafe.scalalogging.LazyLogging
+import com.github.tototoshi.csv.CSVReader
+import scala.collection.JavaConverters;
+
+import utest._
+
+/**
+ * Test whether Shacli works as an executable on particular inputs.
+ */
+
+object ShacliAppTest extends TestSuite {
+  /** Encapsulates the response from exec() */
+  case class ExecResult(exitCode: Int, stdout: String, stderr: String)
+
+  /**
+   * Execute programs from the command line.
+   * Returns the tuple: (exitCode, )
+  */
+  def exec(args: Seq[String]): ExecResult = {
+    val stdout = new StringBuilder
+    val stderr = new StringBuilder
+
+    val status = args ! ProcessLogger(stdout append _, stderr append _)
+    ExecResult(status, stdout.toString, stderr.toString)
+  }
+
+  val tests = Tests {
+    test("Whether Shacli can be started with '--help'") {
+      val res = exec(Seq("sbt", "run --help"))
+      assert(res.exitCode == 0)
+      assert(res.stdout contains "[success] Total time")
+      assert(res.stdout contains "SHACLI: A SHACLI CLI")
+      assert(res.stdout contains "-h, --help")
+      assert(res.stdout contains "Show help message")
+    }
+  }
+}

--- a/src/test/scala/org/renci/shacli/ShacliAppTest.scala
+++ b/src/test/scala/org/renci/shacli/ShacliAppTest.scala
@@ -60,5 +60,18 @@ object ShacliAppTest extends TestSuite {
       assert(res.stdout contains "-h, --help")
       assert(res.stdout contains "Show help message")
     }
+
+    test("Whether Shacli validates a file as expected") {
+      val test1shapes = new File(getClass.getResource("/test1_shapes.ttl").toURI)
+      val test1data = new File(getClass.getResource("/test1_data.ttl").toURI)
+
+      val res = exec(Seq("sbt", s"run $test1shapes $test1data"))
+      assert(res.exitCode == 1)
+      assert(res.stdout contains "Node http://example.org/Shadow (1 errors)")
+      assert(res.stdout contains "- [http://www.w3.org/ns/shacl#MaxCountConstraintComponent] Property may only have 1 value, but found 2")
+      assert(res.stdout contains "[info] 1 errors displayed")
+      assert(res.stdout contains "Nonzero exit code returned from runner: 1")
+      assert(res.stderr == "")
+    }
   }
 }

--- a/src/test/scala/org/renci/shacli/ShacliAppTest.scala
+++ b/src/test/scala/org/renci/shacli/ShacliAppTest.scala
@@ -59,7 +59,6 @@ object ShacliAppTest extends TestSuite {
       assert(res.stdout contains "SHACLI: A SHACLI CLI")
       assert(res.stdout contains "-h, --help")
       assert(res.stdout contains "Show help message")
-      assert(res.stderr == "")
     }
 
     test("Whether Shacli validates a file as expected") {
@@ -72,7 +71,6 @@ object ShacliAppTest extends TestSuite {
       assert(res.stdout contains "- [http://www.w3.org/ns/shacl#MaxCountConstraintComponent] Property may only have 1 value, but found 2")
       assert(res.stdout contains "[info] 1 errors displayed")
       assert(res.stdout contains "Nonzero exit code returned from runner: 1")
-      assert(res.stderr == "")
     }
   }
 }

--- a/src/test/scala/org/renci/shacli/ShacliAppTest.scala
+++ b/src/test/scala/org/renci/shacli/ShacliAppTest.scala
@@ -59,6 +59,7 @@ object ShacliAppTest extends TestSuite {
       assert(res.stdout contains "SHACLI: A SHACLI CLI")
       assert(res.stdout contains "-h, --help")
       assert(res.stdout contains "Show help message")
+      assert(res.stderr == "")
     }
 
     test("Whether Shacli validates a file as expected") {


### PR DESCRIPTION
This PR adds some basic tests for Shacli: making sure we can run it with `--help` to get some help information, and with a shape file and a data file to validate the data against the shapes. Also adds Travis CI support.