### PR TITLE
Check for untested resources

### DIFF
--- a/src/main/scala/org/renci/shacli/ShacliApp.scala
+++ b/src/main/scala/org/renci/shacli/ShacliApp.scala
@@ -89,7 +89,11 @@ object ValidationErrorGenerator {
       "(null)"
     } else if (node.canAs(classOf[RDFList])) {
       val list: RDFList = node.as(classOf[RDFList])
-      list.asJavaList.asScala.toSeq.map(summarizeResource(_)).mkString(", ")
+      list.asJavaList // Convert the JavaList into a java.util.List<RDFNode>,
+      .asScala        // which we then convert into a Scala Buffer, and then
+      .toSeq          // to a Seq.
+        .map(summarizeResource(_))
+        .mkString(", ")
     } else if (node.asNode.isBlank) {
       val byteArray = new ByteArrayOutputStream()
       node.asResource.listProperties.toModel.write(byteArray, "TURTLE") // Accepts "JSON-LD"!

--- a/src/main/scala/org/renci/shacli/ShacliApp.scala
+++ b/src/main/scala/org/renci/shacli/ShacliApp.scala
@@ -10,9 +10,7 @@ import org.apache.jena.ontology.OntModelSpec
 import org.apache.jena.rdf.model.{Model, ModelFactory, Resource, RDFNode, RDFList}
 import org.apache.jena.riot.RDFDataMgr
 import org.apache.jena.util.FileUtils
-import org.topbraid.jenax.util.JenaUtil
 import org.topbraid.jenax.util.SystemTriples
-import org.topbraid.jenax.progress.SimpleProgressMonitor
 import org.topbraid.shacl.util.SHACLSystemModel
 import org.topbraid.shacl.vocabulary.SH
 import org.apache.jena.vocabulary.RDF
@@ -182,7 +180,7 @@ object ShacliApp extends App with LazyLogging {
 
   // Report on any nodes that were not checked.
   val resourcesChecked: Set[RDFNode] = resourcesCheckedSet.toSet
-  val resourcesNotChecked = resourcesToCheck.filter(rdfNode => !resourcesChecked.contains(rdfNode))
+  val resourcesNotChecked: Seq[Resource] = resourcesToCheck.filter(rdfNode => !resourcesChecked.contains(rdfNode))
 
   /** Summarize a set of URIs as a string. */
   def getShortenedURIs(nodes: Seq[Resource]): String = {

--- a/src/main/scala/org/renci/shacli/ShacliApp.scala
+++ b/src/main/scala/org/renci/shacli/ShacliApp.scala
@@ -136,7 +136,7 @@ object ShacliApp extends App with LazyLogging {
   val ignoreConstraints: List[String] = conf.ignore()
 
   // Load the shapes.
-  val shapesModel: Model       = RDFDataMgr.loadModel(shapesFile.toString)
+  val shapesModel: Model = RDFDataMgr.loadModel(shapesFile.toString)
 
   // Load SHACL and Dash.
   val shaclTTL: InputStream = classOf[SHACLSystemModel].getResourceAsStream("/rdf/shacl.ttl")
@@ -151,7 +151,7 @@ object ShacliApp extends App with LazyLogging {
   val shapesOntModel: OntModel = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM, shapesModel)
 
   // Load the data model.
-  val dataModel: Model = RDFDataMgr.loadModel(dataFile.toString);
+  val dataModel: Model                = RDFDataMgr.loadModel(dataFile.toString);
   val resourcesToCheck: Seq[Resource] = dataModel.listSubjects.toList.asScala
   logger.debug(s"Resources to check: ${resourcesToCheck}")
 
@@ -180,27 +180,34 @@ object ShacliApp extends App with LazyLogging {
 
   // Report on any nodes that were not checked.
   val resourcesChecked: Set[RDFNode] = resourcesCheckedSet.toSet
-  val resourcesNotChecked: Seq[Resource] = resourcesToCheck.filter(rdfNode => !resourcesChecked.contains(rdfNode))
+  val resourcesNotChecked: Seq[Resource] =
+    resourcesToCheck.filter(rdfNode => !resourcesChecked.contains(rdfNode))
 
   /** Summarize a set of URIs as a string. */
   def getShortenedURIs(nodes: Seq[Resource]): String = {
-    if (nodes.isEmpty) return "none" else
-    return nodes.map(node => {
-      // Try to use either the data model or the shape model to shorten URLs.
-      val dataModelQName = dataModel.qnameFor(node.getURI)
-      val shapesModelQName = shapesModel.qnameFor(node.getURI)
+    if (nodes.isEmpty) return "none"
+    else
+      return nodes
+        .map(node => {
+          // Try to use either the data model or the shape model to shorten URLs.
+          val dataModelQName   = dataModel.qnameFor(node.getURI)
+          val shapesModelQName = shapesModel.qnameFor(node.getURI)
 
-      return if (dataModelQName != null) dataModelQName
-      else if(shapesModelQName != null) shapesModelQName
-      else node.getURI
-    }).mkString(", ")
+          return if (dataModelQName != null) dataModelQName
+          else if (shapesModelQName != null) shapesModelQName
+          else node.getURI
+        })
+        .mkString(", ")
   }
 
   if (!resourcesNotChecked.isEmpty) {
     resourcesNotChecked.foreach(rdfNode => {
-      val types = rdfNode.asResource.listProperties(RDF.`type`).toList.asScala.map(_.getResource).toSeq
+      val types =
+        rdfNode.asResource.listProperties(RDF.`type`).toList.asScala.map(_.getResource).toSeq
       val props = rdfNode.asResource.listProperties.toList.asScala.map(_.getPredicate).toSeq
-      logger.warn(s"Resource ${rdfNode} (types: ${getShortenedURIs(types)}; props: ${getShortenedURIs(props)}) was not checked.")
+      logger.warn(
+        s"Resource ${rdfNode} (types: ${getShortenedURIs(types)}; props: ${getShortenedURIs(props)}) was not checked."
+      )
     })
     logger.warn(f"${resourcesNotChecked.size}%,d resources NOT checked.")
   }
@@ -261,9 +268,8 @@ object ShacliApp extends App with LazyLogging {
                   // Display focusNode as Turtle.
                   val focusNodeModel =
                     focusNode.inModel(dataModel).asResource.listProperties.toModel
-                  focusNodeModel.setNsPrefixes(
-                    Map("SEPIO" -> "http://purl.obolibrary.org/obo/SEPIO_").asJava
-                  )
+                  focusNodeModel
+                    .setNsPrefixes(Map("SEPIO" -> "http://purl.obolibrary.org/obo/SEPIO_").asJava)
 
                   val stringWriter = new StringWriter
                   focusNodeModel.write(stringWriter, "Turtle")

--- a/src/main/scala/org/renci/shacli/ShacliApp.scala
+++ b/src/main/scala/org/renci/shacli/ShacliApp.scala
@@ -155,7 +155,7 @@ object ShacliApp extends App with LazyLogging {
   // Load the data model.
   val dataModel: Model = RDFDataMgr.loadModel(dataFile.toString);
   val resourcesToCheck: Seq[Resource] = dataModel.listSubjects.toList.asScala
-  logger.info(s"Resources to check: ${resourcesToCheck}")
+  logger.debug(s"Resources to check: ${resourcesToCheck}")
 
   // Create a validation engine.
   val config: ValidationEngineConfiguration = new ValidationEngineConfiguration()
@@ -184,13 +184,15 @@ object ShacliApp extends App with LazyLogging {
   val resourcesChecked: Set[RDFNode] = resourcesCheckedSet.toSet
   val resourcesNotChecked = resourcesToCheck.filter(rdfNode => !resourcesChecked.contains(rdfNode))
 
-  logger.info(f"${resourcesChecked.size}%,d resources checked.")
   if (!resourcesNotChecked.isEmpty) {
-    logger.warn(f"${resourcesNotChecked.size}%,d resources NOT checked.")
     resourcesNotChecked.foreach(rdfNode => {
-      logger.warn(s"Resource ${rdfNode} was not checked.")
+      val types = rdfNode.asResource.listProperties(RDF.`type`).toList.asScala.map(_.getObject)
+      val props = rdfNode.asResource.listProperties.toList.asScala.map(_.getPredicate)
+      logger.warn(s"Resource ${rdfNode} (${types}, ${props}) was not checked.")
     })
+    logger.warn(f"${resourcesNotChecked.size}%,d resources NOT checked.")
   }
+  logger.info(f"${resourcesChecked.size}%,d resources checked.")
 
   if (report.conforms) {
     println("OK")

--- a/src/test/resources/test1_data.ttl
+++ b/src/test/resources/test1_data.ttl
@@ -11,3 +11,14 @@ example:Shadow a example:Dog ;
   foaf:name "Shadow The Sheepdog" ;
   foaf:age 1
 .
+
+example:Buck a example:Dog ;
+  foaf:name "Buck" ;
+  foaf:age 2
+.
+
+# A non-dog so we know it was not tested.
+example:CheshireCat foaf:name "Cheshire Cat" ;
+  foaf:name "Unitary Authority of Warrington Cat" ;
+  foaf:age 232
+.

--- a/src/test/scala/org/renci/shacli/ShacliAppTest.scala
+++ b/src/test/scala/org/renci/shacli/ShacliAppTest.scala
@@ -54,7 +54,7 @@ object ShacliAppTest extends TestSuite {
       // Turtle file (example:CheshireCat) that was not validated.
       assert(res.stdout contains "2 resources checked.")
       assert(res.stdout contains "1 resources NOT checked.")
-      assert(res.stdout contains "Resource http://example.org/CheshireCat was not checked.")
+      assert(res.stdout contains "Resource http://example.org/CheshireCat (types: none; props: foaf:age) was not checked.")
     }
 
     test("Whether Shacli validates a JSON-LD file as expected") {

--- a/src/test/scala/org/renci/shacli/ShacliAppTest.scala
+++ b/src/test/scala/org/renci/shacli/ShacliAppTest.scala
@@ -54,7 +54,9 @@ object ShacliAppTest extends TestSuite {
       // Turtle file (example:CheshireCat) that was not validated.
       assert(res.stdout contains "2 resources checked.")
       assert(res.stdout contains "1 resources NOT checked.")
-      assert(res.stdout contains "Resource http://example.org/CheshireCat (types: none; props: foaf:age) was not checked.")
+      assert(
+        res.stdout contains "Resource http://example.org/CheshireCat (types: none; props: foaf:age) was not checked."
+      )
     }
 
     test("Whether Shacli validates a JSON-LD file as expected") {

--- a/src/test/scala/org/renci/shacli/ShacliAppTest.scala
+++ b/src/test/scala/org/renci/shacli/ShacliAppTest.scala
@@ -49,6 +49,12 @@ object ShacliAppTest extends TestSuite {
       )
       assert(res.stdout contains "[info] 1 errors displayed")
       assert(res.stdout contains "Nonzero exit code returned from runner: 1")
+
+      // Additionally, we should provide a warning: there is a resource in the
+      // Turtle file (example:CheshireCat) that was not validated.
+      assert(res.stdout contains "2 resources checked.")
+      assert(res.stdout contains "1 resources NOT checked.")
+      assert(res.stdout contains "Resource http://example.org/CheshireCat was not checked.")
     }
 
     test("Whether Shacli validates a JSON-LD file as expected") {


### PR DESCRIPTION
This PR adds a check for resources that aren't checked during validation. These are reported as warnings to the user.

Additionally, this cleans up our previous use of JavaConverters to make the code easier to read.