### PR TITLE
Add support for RDF Lists

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,9 @@ libraryDependencies ++= {
     // Import Apache Jena to read JSON-LD.
     "org.apache.jena"             % "jena-core"               % "3.14.0",
 
+    // https://mvnrepository.com/artifact/org.apache.jena/jena-arq
+    "org.apache.jena"             % "jena-arq"                % "3.14.0",
+
     // Import a SHACL library.
     "org.topbraid"                % "shacl"                   % "1.3.0",
 

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ libraryDependencies ++= {
     "org.apache.jena"             % "jena-arq"                % "3.14.0",
 
     // Import a SHACL library.
-    "org.topbraid"                % "shacl"                   % "1.3.0",
+    "org.topbraid"                % "shacl"                   % "1.3.1",
 
     // Add support for CSV
     "com.github.tototoshi"        %% "scala-csv"              % "1.3.6",

--- a/src/main/scala/org/renci/shacli/ShacliApp.scala
+++ b/src/main/scala/org/renci/shacli/ShacliApp.scala
@@ -5,8 +5,7 @@ import java.io.File
 import java.io.{InputStream, File, ByteArrayOutputStream, StringWriter}
 
 import org.topbraid.shacl.validation._
-import org.apache.jena.ontology.OntModel
-import org.apache.jena.ontology.OntModelSpec
+import org.apache.jena.ontology.{OntModel, OntModelSpec}
 import org.apache.jena.rdf.model.{Model, ModelFactory, Resource, RDFNode, RDFList}
 import org.apache.jena.riot.RDFDataMgr
 import org.apache.jena.util.FileUtils
@@ -152,11 +151,7 @@ object ShacliApp extends App with LazyLogging {
   val shapesModel: Model = RDFDataMgr.loadModel(shapesFile.toString)
 
   // Load SHACL and Dash.
-  val shaclTTL: InputStream = classOf[SHACLSystemModel].getResourceAsStream("/rdf/shacl.ttl")
-  shapesModel.read(shaclTTL, SH.BASE_URI, FileUtils.langTurtle)
-
-  val dashTTL: InputStream = classOf[SHACLSystemModel].getResourceAsStream("/rdf/dash.ttl")
-  shapesModel.read(dashTTL, SH.BASE_URI, FileUtils.langTurtle)
+  shapesModel.add(SHACLSystemModel.getSHACLModel)
 
   // Load system ontology.
   shapesModel.add(SystemTriples.getVocabularyModel())

--- a/src/main/scala/org/renci/shacli/ShacliApp.scala
+++ b/src/main/scala/org/renci/shacli/ShacliApp.scala
@@ -151,6 +151,8 @@ object ShacliApp extends App with LazyLogging {
   val shapesModel: Model = RDFDataMgr.loadModel(shapesFile.toString)
 
   // Load SHACL and Dash.
+  val dashTTL: InputStream = classOf[SHACLSystemModel].getResourceAsStream("/rdf/dash.ttl")
+  shapesModel.read(dashTTL, SH.BASE_URI, FileUtils.langTurtle)
   shapesModel.add(SHACLSystemModel.getSHACLModel)
 
   // Load system ontology.
@@ -199,28 +201,43 @@ object ShacliApp extends App with LazyLogging {
       if (nodes.isEmpty) return "none"
       else
         return nodes
-          .map(node => {
-            // Try to use either the data model or the shape model to shorten URLs.
-            val dataModelQName   = dataModel.qnameFor(node.getURI)
-            val shapesModelQName = shapesModel.qnameFor(node.getURI)
+            .map(node => {
+              // Try to use either the data model or the shape model to shorten URLs.
+              val dataModelQName   = dataModel.qnameFor(node.getURI)
+              val shapesModelQName = shapesModel.qnameFor(node.getURI)
 
-            return if (dataModelQName != null) dataModelQName
-            else if (shapesModelQName != null) shapesModelQName
-            else node.getURI
-          })
-          .mkString(", ")
+              if (dataModelQName != null) dataModelQName
+              else if (shapesModelQName != null) shapesModelQName
+              else node.getURI
+            })
+            .mkString(", ")
     }
 
     if (!resourcesNotChecked.isEmpty) {
-      resourcesNotChecked.foreach(rdfNode => {
-        val types =
-          rdfNode.asResource.listProperties(RDF.`type`).toList.asScala.map(_.getResource).toSeq
-        val props = rdfNode.asResource.listProperties.toList.asScala.map(_.getPredicate).toSeq
-        logger.warn(
-          s"Resource ${rdfNode} (types: ${getShortenedURIs(types)}; props: ${getShortenedURIs(props)}) was not checked."
-        )
-      })
-      logger.warn(f"${resourcesNotChecked.size}%,d resources NOT checked.")
+      val filteredResourcesNotChecked = resourcesNotChecked
+        .filter(rdfNode => {
+          // Filter out any RDF Nodes that appear to be well-formed rdf:List.
+          // This means they should have *both* rdf:first and rdf:rest.
+          val props = rdfNode.asResource.listProperties.toList.asScala.map(_.getPredicate).toSet
+
+          if (
+            props.size == 2 &&
+            (props contains RDF.first) &&
+            (props contains RDF.rest)
+          ) false
+          else true
+        })
+
+      filteredResourcesNotChecked
+        .foreach(rdfNode => {
+          val types =
+            rdfNode.asResource.listProperties(RDF.`type`).toList.asScala.map(_.getResource).toSeq
+          val props = rdfNode.asResource.listProperties.toList.asScala.map(_.getPredicate).toSeq
+          logger.warn(
+            s"Resource ${rdfNode} (types: ${getShortenedURIs(types)}; props: ${getShortenedURIs(props)}) was not checked."
+          )
+        })
+      logger.warn(f"${filteredResourcesNotChecked.size}%,d resources NOT checked.")
     }
     logger.info(f"${resourcesChecked.size}%,d resources checked.")
 

--- a/src/test/resources/test1_data.jsonld
+++ b/src/test/resources/test1_data.jsonld
@@ -20,6 +20,11 @@
     "age": {
       "@id": "foaf:age",
       "@type": "xsd:integer"
+    },
+
+    "depiction": {
+      "@id": "foaf:depiction",
+      "@container": "@list"
     }
   },
 
@@ -33,6 +38,18 @@
         "Shadow The Sheepdog"
       ],
       "age": 1
-    }
+    },
+    {
+      "@id": "example:CheshireCat",
+      "@type": "example:Cat",
+      "name": [
+        "Cheshire Cat",
+        "Unitary Authority of Warrington Cat"
+      ],
+      "age": 232,
+      "depiction": [
+        "https://upload.wikimedia.org/wikipedia/commons/a/ab/Tennel_Cheshire_proof.png",
+        "https://upload.wikimedia.org/wikipedia/en/4/4b/Cheshire_Cat_McGee.jpg"
+      ]
   ]
 }

--- a/src/test/resources/test1_data.jsonld
+++ b/src/test/resources/test1_data.jsonld
@@ -51,5 +51,6 @@
         "https://upload.wikimedia.org/wikipedia/commons/a/ab/Tennel_Cheshire_proof.png",
         "https://upload.wikimedia.org/wikipedia/en/4/4b/Cheshire_Cat_McGee.jpg"
       ]
+    }
   ]
 }

--- a/src/test/resources/test1_data.ttl
+++ b/src/test/resources/test1_data.ttl
@@ -9,7 +9,11 @@
 example:Shadow a example:Dog ;
   foaf:name "Shadow" ;
   foaf:name "Shadow The Sheepdog" ;
-  foaf:age 1
+  foaf:age 1 ;
+  foaf:depiction (
+    "https://4.bp.blogspot.com/-1hz9RrOt68Q/URm9CoOovtI/AAAAAAAADDE/6oV4bmfuhOY/s1600/IMG_1236.JPG"
+    "https://www.enidblytonsociety.co.uk/author/illustrations/620wide+2863699.jpg"
+  )
 .
 
 example:Buck a example:Dog ;
@@ -20,5 +24,12 @@ example:Buck a example:Dog ;
 # A non-dog so we know it was not tested.
 example:CheshireCat foaf:name "Cheshire Cat" ;
   foaf:name "Unitary Authority of Warrington Cat" ;
-  foaf:age 232
+  foaf:age 232 ;
+  foaf:depiction [
+    rdf:first "https://upload.wikimedia.org/wikipedia/commons/a/ab/Tennel_Cheshire_proof.png" ;
+    rdf:next [
+      rdf:first "https://upload.wikimedia.org/wikipedia/en/4/4b/Cheshire_Cat_McGee.jpg" ;
+      rdf:next rdf:nil
+    ]
+  ]
 .

--- a/src/test/resources/test1_data.ttl
+++ b/src/test/resources/test1_data.ttl
@@ -10,15 +10,25 @@ example:Shadow a example:Dog ;
   foaf:name "Shadow" ;
   foaf:name "Shadow The Sheepdog" ;
   foaf:age 1 ;
-  foaf:depiction (
-    "https://4.bp.blogspot.com/-1hz9RrOt68Q/URm9CoOovtI/AAAAAAAADDE/6oV4bmfuhOY/s1600/IMG_1236.JPG"
-    "https://www.enidblytonsociety.co.uk/author/illustrations/620wide+2863699.jpg"
-  )
+  foaf:depiction [
+    rdf:first <https://4.bp.blogspot.com/-1hz9RrOt68Q/URm9CoOovtI/AAAAAAAADDE/6oV4bmfuhOY/s1600/IMG_1236.JPG> ;
+    rdf:rest [
+      rdf:first <https://www.enidblytonsociety.co.uk/author/illustrations/620wide+2863699.jpg> ;
+      rdf:rest rdf:nil
+    ]
+  ]
 .
 
 example:Buck a example:Dog ;
   foaf:name "Buck" ;
-  foaf:age 2
+  foaf:age 2 ;
+  foaf:depiction [
+    rdf:first <https://journeyintothecallofthewild.weebly.com/uploads/2/0/7/7/20771194/1086542.jpeg> ;
+    rdf:rest [
+      rdf:first <http://callofthewildbr.tripod.com/sitebuildercontent/sitebuilderpictures/buck2.jpg> ;
+      # rdf:rest rdf:nil
+    ]
+  ]
 .
 
 # A non-dog so we know it was not tested.
@@ -26,10 +36,10 @@ example:CheshireCat foaf:name "Cheshire Cat" ;
   foaf:name "Unitary Authority of Warrington Cat" ;
   foaf:age 232 ;
   foaf:depiction [
-    rdf:first "https://upload.wikimedia.org/wikipedia/commons/a/ab/Tennel_Cheshire_proof.png" ;
-    rdf:next [
-      rdf:first "https://upload.wikimedia.org/wikipedia/en/4/4b/Cheshire_Cat_McGee.jpg" ;
-      rdf:next rdf:nil
+    rdf:first <https://upload.wikimedia.org/wikipedia/commons/a/ab/Tennel_Cheshire_proof.png> ;
+    rdf:rest [
+      rdf:first <https://upload.wikimedia.org/wikipedia/en/4/4b/Cheshire_Cat_McGee.jpg> ;
+      # rdf:rest rdf:nil
     ]
   ]
 .

--- a/src/test/resources/test1_shapes.ttl
+++ b/src/test/resources/test1_shapes.ttl
@@ -2,6 +2,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dash: <http://datashapes.org/dash#> .
 
 @prefix example: <http://example.org/> .
 
@@ -17,5 +18,10 @@ example:DogShape a sh:NodeShape ;
     sh:path foaf:name ;
     sh:minCount 1 ;
     sh:maxCount 1
+  ] ;
+  sh:property [
+    sh:path foaf:depiction ;
+    sh:node dash:ListShape ;
+    sh:minCount 0
   ]
 .

--- a/src/test/scala/org/renci/shacli/ShacliAppTest.scala
+++ b/src/test/scala/org/renci/shacli/ShacliAppTest.scala
@@ -45,18 +45,22 @@ object ShacliAppTest extends TestSuite {
       assert(res.exitCode == 1)
       assert(res.stdout contains "Starting validation of")
       assert(res.stdout contains "Node http://example.org/Shadow (1 errors)")
+      assert(res.stdout contains "Node http://example.org/Buck (1 errors)")
       assert(
         res.stdout contains "- [http://www.w3.org/ns/shacl#MaxCountConstraintComponent] Property may only have 1 value, but found 2"
       )
-      assert(res.stdout contains "[info] 1 errors displayed")
+      assert(res.stdout contains "[info] 2 errors displayed")
       assert(res.stdout contains "Nonzero exit code returned from runner: 1")
+
+      // Make sure we detect that the list in Buck foaf:depiction is broken.
+      assert(res.stdout contains "[http://www.w3.org/ns/shacl#NodeConstraintComponent] Value does not have shape dash:ListShape")
 
       // Additionally, we should provide a warning: there is a resource in the
       // Turtle file (example:CheshireCat) that was not validated.
       assert(res.stdout contains "2 resources checked.")
-      assert(res.stdout contains "1 resources NOT checked.")
+      assert(res.stdout contains "3 resources NOT checked.")
       assert(
-        res.stdout contains "Resource http://example.org/CheshireCat (types: none; props: foaf:age) was not checked."
+        res.stdout contains "Resource http://example.org/CheshireCat (types: none; props: foaf:depiction, foaf:age, foaf:name, foaf:name) was not checked."
       )
     }
 
@@ -84,10 +88,15 @@ object ShacliAppTest extends TestSuite {
       assert(res.exitCode == 1)
       assert(res.stdout contains "Starting validation of")
       assert(res.stdout contains "Node http://example.org/Shadow (1 errors)")
+
+      // Make sure we detect that the list in Buck foaf:depiction is broken.
+      assert(res.stdout contains "Node http://example.org/Buck (1 errors)")
+      assert(res.stdout contains "[http://www.w3.org/ns/shacl#NodeConstraintComponent] Value does not have shape dash:ListShape")
+
       assert(
         res.stdout contains "- [http://www.w3.org/ns/shacl#MaxCountConstraintComponent] Property may only have 1 value, but found 2"
       )
-      assert(res.stdout contains "[info] 1 errors displayed")
+      assert(res.stdout contains "[info] 2 errors displayed")
       assert(res.stdout contains "Nonzero exit code returned from runner: 1")
       assert(res.stdout contains "test1_data.ttl FAILED VALIDATION")
       assert(res.stdout contains "test1_data.jsonld FAILED VALIDATION")


### PR DESCRIPTION
This PR adds support for RDF lists in three ways:
- Added Jena ARQ, which is needed by Dash to implement `dash:ListShape`.
- Updated unchecked resources so that resources that appear to be an rdf:List (by having BOTH an rdf:first and an rdf:rest property) will not produce a warning.
- Added tests to ensure that malformed lists will successfully produce a validation error when validated with `dash:ListShape`.

This PR also fixes a minor bug in displaying the properties of unchecked resources.