### PR TITLE
Added support and tests for multiple data files

### DIFF
--- a/src/main/scala/org/renci/shacli/ShacliApp.scala
+++ b/src/main/scala/org/renci/shacli/ShacliApp.scala
@@ -164,6 +164,8 @@ object ShacliApp extends App with LazyLogging {
   val shapesOntModel: OntModel = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM, shapesModel)
 
   def checkDataFile(dataFile: File): Boolean = {
+    logger.info(s"Starting validation of $dataFile against $shapesFile.")
+
     // Load the data model.
     val dataModel: Model                = RDFDataMgr.loadModel(dataFile.toString);
     val resourcesToCheck: Seq[Resource] = dataModel.listSubjects.toList.asScala

--- a/src/test/scala/org/renci/shacli/ShacliAppTest.scala
+++ b/src/test/scala/org/renci/shacli/ShacliAppTest.scala
@@ -72,5 +72,22 @@ object ShacliAppTest extends TestSuite {
       assert(res.stdout contains "[info] 1 errors displayed")
       assert(res.stdout contains "Nonzero exit code returned from runner: 1")
     }
+
+    test("Whether Shacli validates two files as expected") {
+      val test1shapes      = new File(getClass.getResource("/test1_shapes.ttl").toURI)
+      val test1data_ttl    = new File(getClass.getResource("/test1_data.ttl").toURI)
+      val test1data_jsonld = new File(getClass.getResource("/test1_data.jsonld").toURI)
+
+      val res = exec(Seq("sbt", s"run $test1shapes $test1data_ttl $test1data_jsonld"))
+      assert(res.exitCode == 1)
+      assert(res.stdout contains "Node http://example.org/Shadow (1 errors)")
+      assert(
+        res.stdout contains "- [http://www.w3.org/ns/shacl#MaxCountConstraintComponent] Property may only have 1 value, but found 2"
+      )
+      assert(res.stdout contains "[info] 1 errors displayed")
+      assert(res.stdout contains "Nonzero exit code returned from runner: 1")
+      assert(res.stdout contains "test1_data.ttl FAILED VALIDATION")
+      assert(res.stdout contains "test1_data.jsonld FAILED VALIDATION")
+    }
   }
 }

--- a/src/test/scala/org/renci/shacli/ShacliAppTest.scala
+++ b/src/test/scala/org/renci/shacli/ShacliAppTest.scala
@@ -43,6 +43,7 @@ object ShacliAppTest extends TestSuite {
 
       val res = exec(Seq("sbt", s"run $test1shapes $test1data"))
       assert(res.exitCode == 1)
+      assert(res.stdout contains "Starting validation of")
       assert(res.stdout contains "Node http://example.org/Shadow (1 errors)")
       assert(
         res.stdout contains "- [http://www.w3.org/ns/shacl#MaxCountConstraintComponent] Property may only have 1 value, but found 2"
@@ -65,6 +66,7 @@ object ShacliAppTest extends TestSuite {
 
       val res = exec(Seq("sbt", s"run $test1shapes $test1data"))
       assert(res.exitCode == 1)
+      assert(res.stdout contains "Starting validation of")
       assert(res.stdout contains "Node http://example.org/Shadow (1 errors)")
       assert(
         res.stdout contains "- [http://www.w3.org/ns/shacl#MaxCountConstraintComponent] Property may only have 1 value, but found 2"
@@ -80,6 +82,7 @@ object ShacliAppTest extends TestSuite {
 
       val res = exec(Seq("sbt", s"run $test1shapes $test1data_ttl $test1data_jsonld"))
       assert(res.exitCode == 1)
+      assert(res.stdout contains "Starting validation of")
       assert(res.stdout contains "Node http://example.org/Shadow (1 errors)")
       assert(
         res.stdout contains "- [http://www.w3.org/ns/shacl#MaxCountConstraintComponent] Property may only have 1 value, but found 2"


### PR DESCRIPTION
This PR extends SHACLI's CLI arguments so that you can run `[shacli] shapefile.ttl data1.ttl data2.ttl data3.ttl`.