### PR TITLE
Divide into subcommands

### DIFF
--- a/src/main/scala/org/renci/shacli/ShacliApp.scala
+++ b/src/main/scala/org/renci/shacli/ShacliApp.scala
@@ -9,7 +9,6 @@ import org.rogach.scallop.exceptions._
 
 import com.typesafe.scalalogging.{LazyLogging, Logger}
 
-
 import org.renci.shacli.validator.Validator
 import org.renci.shacli.generator.Generator
 
@@ -19,7 +18,6 @@ import org.renci.shacli.generator.Generator
   * TopBraid's SHACL engine.
   */
 object ShacliApp extends App with LazyLogging {
-
   /**
     * Command line configuration for Validate.
     */
@@ -36,8 +34,10 @@ object ShacliApp extends App with LazyLogging {
     version("SHACLI: A SHACLI CLI v" + version)
     val validate: validate = new validate
     class validate extends Subcommand("validate") {
-      val shapes: ScallopOption[File] = trailArg[File](descr = "Shapes file to validate (in Turtle)")
-      val data: ScallopOption[List[File]]   = trailArg[List[File]](descr = "Data file(s) to validate (in Turtle)")
+      val shapes: ScallopOption[File] =
+        trailArg[File](descr = "Shapes file to validate (in Turtle)")
+      val data: ScallopOption[List[File]] =
+        trailArg[List[File]](descr = "Data file(s) to validate (in Turtle)")
       val only: ScallopOption[List[String]] = opt[List[String]](
         default = Some(List()),
         descr = "Only display SourceConstraintComponent ending with these strings"
@@ -55,7 +55,8 @@ object ShacliApp extends App with LazyLogging {
     // that represents the presented content.
     val generate: generate = new generate
     class generate extends Subcommand("generate") {
-      val data: ScallopOption[List[File]] = trailArg[List[File]](descr = "Data file(s) to validate (in Turtle)")
+      val data: ScallopOption[List[File]] =
+        trailArg[List[File]](descr = "Data file(s) to validate (in Turtle)")
     }
     addSubcommand(generate)
 
@@ -68,6 +69,6 @@ object ShacliApp extends App with LazyLogging {
   conf.subcommand match {
     case Some(conf.validate) => System.exit(Validator.validate(logger, conf))
     case Some(conf.generate) => System.exit(Generator.generate(logger, conf))
-    case _ => throw new RuntimeException("Unknown subcommand: " + conf.subcommand)
+    case _                   => throw new RuntimeException("Unknown subcommand: " + conf.subcommand)
   }
 }

--- a/src/main/scala/org/renci/shacli/ShacliApp.scala
+++ b/src/main/scala/org/renci/shacli/ShacliApp.scala
@@ -2,25 +2,13 @@ package org.renci.shacli
 
 import java.io.File
 
-import java.io.{InputStream, File, ByteArrayOutputStream, StringWriter}
+import java.io.File
 
-import org.topbraid.shacl.validation._
-import org.apache.jena.ontology.{OntModel, OntModelSpec}
-import org.apache.jena.rdf.model.{Model, ModelFactory, Resource, RDFNode, RDFList}
-import org.apache.jena.riot.RDFDataMgr
-import org.apache.jena.util.FileUtils
-import org.topbraid.jenax.util.SystemTriples
-import org.topbraid.shacl.util.SHACLSystemModel
-import org.topbraid.shacl.vocabulary.SH
-import org.apache.jena.vocabulary.RDF
-import org.apache.jena.vocabulary.RDFS
 import org.rogach.scallop._
 import org.rogach.scallop.exceptions._
 
 import com.typesafe.scalalogging.{LazyLogging, Logger}
 
-import scala.collection.JavaConverters._
-import scala.collection.mutable
 
 import org.renci.shacli.validator.Validator
 import org.renci.shacli.generator.Generator
@@ -36,7 +24,7 @@ object ShacliApp extends App with LazyLogging {
     * Command line configuration for Validate.
     */
   class Conf(arguments: Seq[String], logger: Logger) extends ScallopConf(arguments) {
-    override def onError(e: Throwable) = e match {
+    override def onError(e: Throwable): Unit = e match {
       case ScallopException(message) =>
         printHelp
         logger.error(message)
@@ -46,7 +34,8 @@ object ShacliApp extends App with LazyLogging {
 
     val version = getClass.getPackage.getImplementationVersion
     version("SHACLI: A SHACLI CLI v" + version)
-    val validate = new Subcommand("validate") {
+    val validate: validate = new validate
+    class validate extends Subcommand("validate") {
       val shapes: ScallopOption[File] = trailArg[File](descr = "Shapes file to validate (in Turtle)")
       val data: ScallopOption[List[File]]   = trailArg[List[File]](descr = "Data file(s) to validate (in Turtle)")
       val only: ScallopOption[List[String]] = opt[List[String]](
@@ -64,7 +53,8 @@ object ShacliApp extends App with LazyLogging {
 
     // If you run `[shacli] generate [data files]`, we will attempt to generate SHACL
     // that represents the presented content.
-    val generate = new Subcommand("generate") {
+    val generate: generate = new generate
+    class generate extends Subcommand("generate") {
       val data: ScallopOption[List[File]] = trailArg[List[File]](descr = "Data file(s) to validate (in Turtle)")
     }
     addSubcommand(generate)

--- a/src/main/scala/org/renci/shacli/ShacliApp.scala
+++ b/src/main/scala/org/renci/shacli/ShacliApp.scala
@@ -22,332 +22,8 @@ import com.typesafe.scalalogging.{LazyLogging, Logger}
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
-/*
- * Better validation errors for SHACL
- */
-
-case class ValidationError(
-  report: ValidationReport,
-  result: ValidationResult,
-  classNode: RDFNode,
-  focusNode: RDFNode,
-  path: String,
-  sourceConstraintComponent: Resource,
-  message: String,
-  value: Option[RDFNode]
-)
-
-object ValidationErrorGenerator {
-  def generate(
-    report: ValidationReport,
-    shapesModel: OntModel,
-    dataModel: Model
-  ): Seq[ValidationError] = {
-    val results = report.results.asScala.toSeq
-
-    // 1. Group results by source shape.
-    val resultsByClass = results.groupBy({ result =>
-      val focusNode = result.getFocusNode
-      val statement = dataModel.getProperty(focusNode.asResource, RDF.`type`)
-
-      if (statement == null) RDFS.Class
-      else statement.getObject
-    })
-    resultsByClass.toSeq
-      .sortBy(_._2.size)
-      .flatMap({
-        case (classNode, classResults) =>
-          val resultsByFocusNode = classResults.groupBy(_.getFocusNode)
-          resultsByFocusNode.toSeq
-            .sortBy(_._2.size)
-            .flatMap({
-              case (focusNode, focusNodeResults) =>
-                val resultsByPath = focusNodeResults.groupBy(_.getPath)
-                resultsByPath.toSeq
-                  .sortBy(_._2.size)
-                  .flatMap({
-                    case (pathNode, pathNodeResults) =>
-                      pathNodeResults.map(result => {
-                        ValidationError(
-                          report,
-                          result,
-                          classNode,
-                          focusNode,
-                          summarizeResource(pathNode),
-                          result.getSourceConstraintComponent,
-                          result.getMessage,
-                          if (result.getValue == null) None else Some(result.getValue)
-                        )
-                      })
-                  })
-            })
-      })
-  }
-
-  def summarizeResource(node: RDFNode): String = {
-    if (node == null) {
-      "(null)"
-    } else if (node.canAs(classOf[RDFList])) {
-      val list: RDFList = node.as(classOf[RDFList])
-      list.asJavaList // Convert the JavaList into a java.util.List<RDFNode>,
-      .asScala        // which we then convert into a Scala Buffer, and then
-      .toSeq          // to a Seq.
-        .map(summarizeResource(_))
-        .mkString(", ")
-    } else if (node.asNode.isBlank) {
-      val byteArray = new ByteArrayOutputStream()
-      node.asResource.listProperties.toModel.write(byteArray, "TURTLE") // Accepts "JSON-LD"!
-      byteArray.toString.replaceAll("\n", " ").replaceAll("\t", " ").replaceAll("\\s+", " ")
-    } else {
-      node.toString
-    }
-  }
-}
-
-/**
- * Validator
- */
-object Validator {
-  def validate(logger: Logger, conf: Conf): Int = {
-    val shapesFile: File                = conf.validate.shapes()
-    val dataFiles: List[File]           = conf.validate.data()
-    val onlyConstraints: List[String]   = conf.validate.only()
-    val ignoreConstraints: List[String] = conf.validate.ignore()
-
-    // Load the shapes.
-    val shapesModel: Model = RDFDataMgr.loadModel(shapesFile.toString)
-
-    // Load SHACL and Dash.
-    val toshTTL: InputStream = classOf[SHACLSystemModel].getResourceAsStream("/rdf/tosh.ttl")
-    shapesModel.read(toshTTL, SH.BASE_URI, FileUtils.langTurtle)
-    shapesModel.add(SHACLSystemModel.getSHACLModel)
-
-    // Load system ontology.
-    shapesModel.add(SystemTriples.getVocabularyModel())
-
-    val shapesOntModel: OntModel = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM, shapesModel)
-
-    def checkDataFile(dataFile: File): Boolean = {
-      logger.info(s"Starting validation of $dataFile against $shapesFile.")
-
-      // Load the data model.
-      val dataModel: Model                = RDFDataMgr.loadModel(dataFile.toString);
-      val resourcesToCheck: Seq[Resource] = dataModel.listSubjects.toList.asScala
-      logger.debug(s"Resources to check: ${resourcesToCheck}")
-
-      // Create a validation engine.
-      val config: ValidationEngineConfiguration = new ValidationEngineConfiguration()
-        .setReportDetails(true)
-        .setValidateShapes(true)
-
-      val engine: ValidationEngine =
-        ValidationUtil.createValidationEngine(dataModel, shapesOntModel, config)
-
-      // Track progress.
-      // TODO: Implement a progress monitor so we can track long-running jobs.
-      // engine.setProgressMonitor(new SimpleProgressMonitor("Progress"))
-
-      // Count off validated nodes.
-      val resourcesCheckedSet: mutable.Set[RDFNode] = mutable.Set()
-      engine.setFocusNodeFilter(rdfNode => {
-        logger.debug(s"Checking focus node ${rdfNode}")
-        resourcesCheckedSet.add(rdfNode)
-        true
-      })
-
-      engine.validateAll()
-      val report = engine.getValidationReport
-
-      // Report on any nodes that were not checked.
-      val resourcesChecked: Set[RDFNode] = resourcesCheckedSet.toSet
-      val resourcesNotChecked: Seq[Resource] =
-        resourcesToCheck.filter(rdfNode => !resourcesChecked.contains(rdfNode))
-
-      /** Summarize a set of URIs as a string. */
-      def getShortenedURIs(nodes: Seq[Resource]): String = {
-        if (nodes.isEmpty) return "none"
-        else
-          return nodes
-              .map(node => {
-                // Try to use either the data model or the shape model to shorten URLs.
-                val dataModelQName   = dataModel.qnameFor(node.getURI)
-                val shapesModelQName = shapesModel.qnameFor(node.getURI)
-
-                if (dataModelQName != null) dataModelQName
-                else if (shapesModelQName != null) shapesModelQName
-                else node.getURI
-              })
-              .mkString(", ")
-      }
-
-      if (!resourcesNotChecked.isEmpty) {
-        val filteredResourcesNotChecked = resourcesNotChecked
-          .filter(rdfNode => {
-            // Filter out any RDF Nodes that appear to be well-formed rdf:List.
-            // This means they should have *both* rdf:first and rdf:rest.
-            val props = rdfNode.asResource.listProperties.toList.asScala.map(_.getPredicate).toSet
-
-            if (
-              props.size == 2 &&
-              (props contains RDF.first) &&
-              (props contains RDF.rest)
-            ) false
-            else true
-          })
-
-        filteredResourcesNotChecked
-          .foreach(rdfNode => {
-            val types =
-              rdfNode.asResource.listProperties(RDF.`type`).toList.asScala.map(_.getResource).toSeq
-            val props = rdfNode.asResource.listProperties.toList.asScala.map(_.getPredicate).toSeq
-            logger.warn(
-              s"Resource ${rdfNode} (types: ${getShortenedURIs(types)}; props: ${getShortenedURIs(props)}) was not checked."
-            )
-          })
-        logger.warn(f"${filteredResourcesNotChecked.size}%,d resources NOT checked.")
-      }
-      logger.info(f"${resourcesChecked.size}%,d resources checked.")
-
-      if (report.conforms) {
-        println(dataFile + " OK")
-        return true;
-      } else {
-        val errors = ValidationErrorGenerator.generate(report, shapesOntModel, dataModel)
-
-        def stringEndsWithOneOf(str: String, oneOf: Seq[String]): Boolean =
-          oneOf.exists(str.endsWith(_))
-
-        val filteredErrors = errors
-          .filter(
-            err =>
-              onlyConstraints.isEmpty || stringEndsWithOneOf(
-                err.sourceConstraintComponent.toString,
-                onlyConstraints
-              )
-          )
-          .filter(
-            err =>
-              ignoreConstraints.isEmpty || !stringEndsWithOneOf(
-                err.sourceConstraintComponent.toString,
-                ignoreConstraints
-              )
-          )
-
-        filteredErrors
-          .groupBy(_.classNode)
-          .foreach({
-            case (classNode, classErrors) =>
-              // TODO: look up the classNode label
-              println(s"CLASS <${classNode}> (${classErrors.length} errors)")
-              classErrors
-                .groupBy(_.focusNode)
-                .foreach({
-                  case (focusNode, focusErrors) =>
-                    println(s"Node ${focusNode} (${focusErrors.length} errors)")
-                    focusErrors
-                      .groupBy(_.path)
-                      .foreach({
-                        case (path, pathErrors) =>
-                          println(s" - Path <${path}> (${pathErrors.length} errors)")
-                          pathErrors.foreach(error => {
-                            println(
-                              s"   - [${error.sourceConstraintComponent}] ${error.message} ${error.value
-                                .map(value => s"(value: $value)")
-                                .mkString(", ")}"
-                            )
-                          })
-                          println()
-                      })
-                    println()
-                    if (conf.validate.displayNodes()) {
-                      // Display focusNode as Turtle.
-                      val focusNodeModel =
-                        focusNode.inModel(dataModel).asResource.listProperties.toModel
-                      focusNodeModel
-                        .setNsPrefixes(Map("SEPIO" -> "http://purl.obolibrary.org/obo/SEPIO_").asJava)
-
-                      val stringWriter = new StringWriter
-                      focusNodeModel.write(stringWriter, "Turtle")
-                      println(s"Focus node model:\n${stringWriter.toString}")
-                    }
-                })
-          })
-
-        println()
-        println(s"${filteredErrors.length} errors displayed")
-
-        val ignoredErrors = errors diff filteredErrors
-        if (!ignoredErrors.isEmpty) {
-          println(s"${ignoredErrors.length} errors ignored because:")
-          onlyConstraints.foreach(
-            only => println(s" - Only displaying sourceConstraintComponents ending in '$only'")
-          )
-          ignoreConstraints.foreach(
-            ignored => println(s" - Ignoring sourceConstraintComponents ending in '$ignored'")
-          )
-        }
-
-        println(dataFile + " FAILED VALIDATION")
-        return false;
-      }
-    }
-
-    if (dataFiles.map(checkDataFile(_)).forall(identity))
-      return 0
-    else
-      return 1
-  }
-}
-
-/**
- * Generate SHACL based on Turtle provided.
- */
-object Generator {
-  def generate(logger: Logger, conf: Conf): Int = {
-    println("Generate with conf: " + conf)
-    return 0
-  }
-}
-
-/**
-  * Command line configuration for Validate.
-  */
-class Conf(arguments: Seq[String], logger: Logger) extends ScallopConf(arguments) {
-  override def onError(e: Throwable) = e match {
-    case ScallopException(message) =>
-      printHelp
-      logger.error(message)
-      System.exit(1)
-    case ex => super.onError(ex)
-  }
-
-  val version = getClass.getPackage.getImplementationVersion
-  version("SHACLI: A SHACLI CLI v" + version)
-  val validate = new Subcommand("validate") {
-    val shapes: ScallopOption[File] = trailArg[File](descr = "Shapes file to validate (in Turtle)")
-    val data: ScallopOption[List[File]]   = trailArg[List[File]](descr = "Data file(s) to validate (in Turtle)")
-    val only: ScallopOption[List[String]] = opt[List[String]](
-      default = Some(List()),
-      descr = "Only display SourceConstraintComponent ending with these strings"
-    )
-    val ignore: ScallopOption[List[String]] = opt[List[String]](
-      default = Some(List()),
-      descr = "Don't display SourceConstraintComponent ending with these strings"
-    )
-    val displayNodes: ScallopOption[Boolean] =
-      opt[Boolean](default = Some(false), descr = "Display all failing nodes as Turtle")
-  }
-  addSubcommand(validate)
-
-  // If you run `[shacli] generate [data files]`, we will attempt to generate SHACL
-  // that represents the presented content.
-  val generate = new Subcommand("generate") {
-    val data: ScallopOption[List[File]] = trailArg[List[File]](descr = "Data file(s) to validate (in Turtle)")
-  }
-  addSubcommand(generate)
-
-  verify()
-}
+import org.renci.shacli.validator.Validator
+import org.renci.shacli.generator.Generator
 
 /**
   * Use the given shapes file to validate the given data file.
@@ -355,6 +31,47 @@ class Conf(arguments: Seq[String], logger: Logger) extends ScallopConf(arguments
   * TopBraid's SHACL engine.
   */
 object ShacliApp extends App with LazyLogging {
+
+  /**
+    * Command line configuration for Validate.
+    */
+  class Conf(arguments: Seq[String], logger: Logger) extends ScallopConf(arguments) {
+    override def onError(e: Throwable) = e match {
+      case ScallopException(message) =>
+        printHelp
+        logger.error(message)
+        System.exit(1)
+      case ex => super.onError(ex)
+    }
+
+    val version = getClass.getPackage.getImplementationVersion
+    version("SHACLI: A SHACLI CLI v" + version)
+    val validate = new Subcommand("validate") {
+      val shapes: ScallopOption[File] = trailArg[File](descr = "Shapes file to validate (in Turtle)")
+      val data: ScallopOption[List[File]]   = trailArg[List[File]](descr = "Data file(s) to validate (in Turtle)")
+      val only: ScallopOption[List[String]] = opt[List[String]](
+        default = Some(List()),
+        descr = "Only display SourceConstraintComponent ending with these strings"
+      )
+      val ignore: ScallopOption[List[String]] = opt[List[String]](
+        default = Some(List()),
+        descr = "Don't display SourceConstraintComponent ending with these strings"
+      )
+      val displayNodes: ScallopOption[Boolean] =
+        opt[Boolean](default = Some(false), descr = "Display all failing nodes as Turtle")
+    }
+    addSubcommand(validate)
+
+    // If you run `[shacli] generate [data files]`, we will attempt to generate SHACL
+    // that represents the presented content.
+    val generate = new Subcommand("generate") {
+      val data: ScallopOption[List[File]] = trailArg[List[File]](descr = "Data file(s) to validate (in Turtle)")
+    }
+    addSubcommand(generate)
+
+    verify()
+  }
+
   // Parse command line arguments.
   val conf = new Conf(args, logger)
 

--- a/src/main/scala/org/renci/shacli/ShacliApp.scala
+++ b/src/main/scala/org/renci/shacli/ShacliApp.scala
@@ -151,8 +151,8 @@ object ShacliApp extends App with LazyLogging {
   val shapesModel: Model = RDFDataMgr.loadModel(shapesFile.toString)
 
   // Load SHACL and Dash.
-  val dashTTL: InputStream = classOf[SHACLSystemModel].getResourceAsStream("/rdf/dash.ttl")
-  shapesModel.read(dashTTL, SH.BASE_URI, FileUtils.langTurtle)
+  val toshTTL: InputStream = classOf[SHACLSystemModel].getResourceAsStream("/rdf/tosh.ttl")
+  shapesModel.read(toshTTL, SH.BASE_URI, FileUtils.langTurtle)
   shapesModel.add(SHACLSystemModel.getSHACLModel)
 
   // Load system ontology.

--- a/src/main/scala/org/renci/shacli/ShacliApp.scala
+++ b/src/main/scala/org/renci/shacli/ShacliApp.scala
@@ -183,7 +183,7 @@ object ShacliApp extends App with LazyLogging {
     // Count off validated nodes.
     val resourcesCheckedSet: mutable.Set[RDFNode] = mutable.Set()
     engine.setFocusNodeFilter(rdfNode => {
-      logger.info(s"Checking focus node ${rdfNode}")
+      logger.debug(s"Checking focus node ${rdfNode}")
       resourcesCheckedSet.add(rdfNode)
       true
     })

--- a/src/main/scala/org/renci/shacli/generator/Generator.scala
+++ b/src/main/scala/org/renci/shacli/generator/Generator.scala
@@ -1,0 +1,35 @@
+package org.renci.shacli.generator
+
+import java.io.File
+
+import java.io.{InputStream, File, ByteArrayOutputStream, StringWriter}
+
+import org.topbraid.shacl.validation._
+import org.apache.jena.ontology.{OntModel, OntModelSpec}
+import org.apache.jena.rdf.model.{Model, ModelFactory, Resource, RDFNode, RDFList}
+import org.apache.jena.riot.RDFDataMgr
+import org.apache.jena.util.FileUtils
+import org.topbraid.jenax.util.SystemTriples
+import org.topbraid.shacl.util.SHACLSystemModel
+import org.topbraid.shacl.vocabulary.SH
+import org.apache.jena.vocabulary.RDF
+import org.apache.jena.vocabulary.RDFS
+import org.rogach.scallop._
+import org.rogach.scallop.exceptions._
+
+import com.typesafe.scalalogging.{LazyLogging, Logger}
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+import org.renci.shacli.ShacliApp
+
+/**
+ * Generate SHACL based on Turtle provided.
+ */
+object Generator {
+  def generate(logger: Logger, conf: ShacliApp.Conf): Int = {
+    println("Generate with conf: " + conf)
+    return 0
+  }
+}

--- a/src/main/scala/org/renci/shacli/generator/Generator.scala
+++ b/src/main/scala/org/renci/shacli/generator/Generator.scala
@@ -1,26 +1,10 @@
 package org.renci.shacli.generator
 
-import java.io.File
 
-import java.io.{InputStream, File, ByteArrayOutputStream, StringWriter}
 
-import org.topbraid.shacl.validation._
-import org.apache.jena.ontology.{OntModel, OntModelSpec}
-import org.apache.jena.rdf.model.{Model, ModelFactory, Resource, RDFNode, RDFList}
-import org.apache.jena.riot.RDFDataMgr
-import org.apache.jena.util.FileUtils
-import org.topbraid.jenax.util.SystemTriples
-import org.topbraid.shacl.util.SHACLSystemModel
-import org.topbraid.shacl.vocabulary.SH
-import org.apache.jena.vocabulary.RDF
-import org.apache.jena.vocabulary.RDFS
-import org.rogach.scallop._
-import org.rogach.scallop.exceptions._
 
-import com.typesafe.scalalogging.{LazyLogging, Logger}
+import com.typesafe.scalalogging.Logger
 
-import scala.collection.JavaConverters._
-import scala.collection.mutable
 
 import org.renci.shacli.ShacliApp
 

--- a/src/main/scala/org/renci/shacli/generator/Generator.scala
+++ b/src/main/scala/org/renci/shacli/generator/Generator.scala
@@ -1,16 +1,12 @@
 package org.renci.shacli.generator
 
-
-
-
 import com.typesafe.scalalogging.Logger
-
 
 import org.renci.shacli.ShacliApp
 
 /**
- * Generate SHACL based on Turtle provided.
- */
+  * Generate SHACL based on Turtle provided.
+  */
 object Generator {
   def generate(logger: Logger, conf: ShacliApp.Conf): Int = {
     println("Generate with conf: " + conf)

--- a/src/main/scala/org/renci/shacli/validator/Validator.scala
+++ b/src/main/scala/org/renci/shacli/validator/Validator.scala
@@ -105,8 +105,8 @@ object ValidationErrorGenerator {
 }
 
 /**
- * Validator
- */
+  * Validator
+  */
 object Validator {
   def validate(logger: Logger, conf: ShacliApp.Conf): Int = {
     val shapesFile: File                = conf.validate.shapes()
@@ -125,7 +125,8 @@ object Validator {
     // Load system ontology.
     shapesModel.add(SystemTriples.getVocabularyModel())
 
-    val shapesOntModel: OntModel = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM, shapesModel)
+    val shapesOntModel: OntModel =
+      ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM, shapesModel)
 
     def checkDataFile(dataFile: File): Boolean = {
       logger.info(s"Starting validation of $dataFile against $shapesFile.")
@@ -168,16 +169,16 @@ object Validator {
         if (nodes.isEmpty) return "none"
         else
           return nodes
-              .map(node => {
-                // Try to use either the data model or the shape model to shorten URLs.
-                val dataModelQName   = dataModel.qnameFor(node.getURI)
-                val shapesModelQName = shapesModel.qnameFor(node.getURI)
+            .map(node => {
+              // Try to use either the data model or the shape model to shorten URLs.
+              val dataModelQName   = dataModel.qnameFor(node.getURI)
+              val shapesModelQName = shapesModel.qnameFor(node.getURI)
 
-                if (dataModelQName != null) dataModelQName
-                else if (shapesModelQName != null) shapesModelQName
-                else node.getURI
-              })
-              .mkString(", ")
+              if (dataModelQName != null) dataModelQName
+              else if (shapesModelQName != null) shapesModelQName
+              else node.getURI
+            })
+            .mkString(", ")
       }
 
       if (!resourcesNotChecked.isEmpty) {
@@ -187,11 +188,9 @@ object Validator {
             // This means they should have *both* rdf:first and rdf:rest.
             val props = rdfNode.asResource.listProperties.toList.asScala.map(_.getPredicate).toSet
 
-            if (
-              props.size == 2 &&
-              (props contains RDF.first) &&
-              (props contains RDF.rest)
-            ) false
+            if (props.size == 2 &&
+                (props contains RDF.first) &&
+                (props contains RDF.rest)) false
             else true
           })
 
@@ -264,7 +263,9 @@ object Validator {
                       val focusNodeModel =
                         focusNode.inModel(dataModel).asResource.listProperties.toModel
                       focusNodeModel
-                        .setNsPrefixes(Map("SEPIO" -> "http://purl.obolibrary.org/obo/SEPIO_").asJava)
+                        .setNsPrefixes(
+                          Map("SEPIO" -> "http://purl.obolibrary.org/obo/SEPIO_").asJava
+                        )
 
                       val stringWriter = new StringWriter
                       focusNodeModel.write(stringWriter, "Turtle")

--- a/src/main/scala/org/renci/shacli/validator/Validator.scala
+++ b/src/main/scala/org/renci/shacli/validator/Validator.scala
@@ -1,0 +1,302 @@
+package org.renci.shacli.validator
+
+import java.io.File
+
+import java.io.{InputStream, File, ByteArrayOutputStream, StringWriter}
+
+import org.topbraid.shacl.validation._
+import org.apache.jena.ontology.{OntModel, OntModelSpec}
+import org.apache.jena.rdf.model.{Model, ModelFactory, Resource, RDFNode, RDFList}
+import org.apache.jena.riot.RDFDataMgr
+import org.apache.jena.util.FileUtils
+import org.topbraid.jenax.util.SystemTriples
+import org.topbraid.shacl.util.SHACLSystemModel
+import org.topbraid.shacl.vocabulary.SH
+import org.apache.jena.vocabulary.RDF
+import org.apache.jena.vocabulary.RDFS
+import org.rogach.scallop._
+import org.rogach.scallop.exceptions._
+
+import com.typesafe.scalalogging.{LazyLogging, Logger}
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+import org.renci.shacli.ShacliApp
+
+/*
+ * Better validation errors for SHACL
+ */
+
+case class ValidationError(
+  report: ValidationReport,
+  result: ValidationResult,
+  classNode: RDFNode,
+  focusNode: RDFNode,
+  path: String,
+  sourceConstraintComponent: Resource,
+  message: String,
+  value: Option[RDFNode]
+)
+
+object ValidationErrorGenerator {
+  def generate(
+    report: ValidationReport,
+    shapesModel: OntModel,
+    dataModel: Model
+  ): Seq[ValidationError] = {
+    val results = report.results.asScala.toSeq
+
+    // 1. Group results by source shape.
+    val resultsByClass = results.groupBy({ result =>
+      val focusNode = result.getFocusNode
+      val statement = dataModel.getProperty(focusNode.asResource, RDF.`type`)
+
+      if (statement == null) RDFS.Class
+      else statement.getObject
+    })
+    resultsByClass.toSeq
+      .sortBy(_._2.size)
+      .flatMap({
+        case (classNode, classResults) =>
+          val resultsByFocusNode = classResults.groupBy(_.getFocusNode)
+          resultsByFocusNode.toSeq
+            .sortBy(_._2.size)
+            .flatMap({
+              case (focusNode, focusNodeResults) =>
+                val resultsByPath = focusNodeResults.groupBy(_.getPath)
+                resultsByPath.toSeq
+                  .sortBy(_._2.size)
+                  .flatMap({
+                    case (pathNode, pathNodeResults) =>
+                      pathNodeResults.map(result => {
+                        ValidationError(
+                          report,
+                          result,
+                          classNode,
+                          focusNode,
+                          summarizeResource(pathNode),
+                          result.getSourceConstraintComponent,
+                          result.getMessage,
+                          if (result.getValue == null) None else Some(result.getValue)
+                        )
+                      })
+                  })
+            })
+      })
+  }
+
+  def summarizeResource(node: RDFNode): String = {
+    if (node == null) {
+      "(null)"
+    } else if (node.canAs(classOf[RDFList])) {
+      val list: RDFList = node.as(classOf[RDFList])
+      list.asJavaList // Convert the JavaList into a java.util.List<RDFNode>,
+      .asScala        // which we then convert into a Scala Buffer, and then
+      .toSeq          // to a Seq.
+        .map(summarizeResource(_))
+        .mkString(", ")
+    } else if (node.asNode.isBlank) {
+      val byteArray = new ByteArrayOutputStream()
+      node.asResource.listProperties.toModel.write(byteArray, "TURTLE") // Accepts "JSON-LD"!
+      byteArray.toString.replaceAll("\n", " ").replaceAll("\t", " ").replaceAll("\\s+", " ")
+    } else {
+      node.toString
+    }
+  }
+}
+
+/**
+ * Validator
+ */
+object Validator {
+  def validate(logger: Logger, conf: ShacliApp.Conf): Int = {
+    val shapesFile: File                = conf.validate.shapes()
+    val dataFiles: List[File]           = conf.validate.data()
+    val onlyConstraints: List[String]   = conf.validate.only()
+    val ignoreConstraints: List[String] = conf.validate.ignore()
+
+    // Load the shapes.
+    val shapesModel: Model = RDFDataMgr.loadModel(shapesFile.toString)
+
+    // Load SHACL and Dash.
+    val toshTTL: InputStream = classOf[SHACLSystemModel].getResourceAsStream("/rdf/tosh.ttl")
+    shapesModel.read(toshTTL, SH.BASE_URI, FileUtils.langTurtle)
+    shapesModel.add(SHACLSystemModel.getSHACLModel)
+
+    // Load system ontology.
+    shapesModel.add(SystemTriples.getVocabularyModel())
+
+    val shapesOntModel: OntModel = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM, shapesModel)
+
+    def checkDataFile(dataFile: File): Boolean = {
+      logger.info(s"Starting validation of $dataFile against $shapesFile.")
+
+      // Load the data model.
+      val dataModel: Model                = RDFDataMgr.loadModel(dataFile.toString);
+      val resourcesToCheck: Seq[Resource] = dataModel.listSubjects.toList.asScala
+      logger.debug(s"Resources to check: ${resourcesToCheck}")
+
+      // Create a validation engine.
+      val config: ValidationEngineConfiguration = new ValidationEngineConfiguration()
+        .setReportDetails(true)
+        .setValidateShapes(true)
+
+      val engine: ValidationEngine =
+        ValidationUtil.createValidationEngine(dataModel, shapesOntModel, config)
+
+      // Track progress.
+      // TODO: Implement a progress monitor so we can track long-running jobs.
+      // engine.setProgressMonitor(new SimpleProgressMonitor("Progress"))
+
+      // Count off validated nodes.
+      val resourcesCheckedSet: mutable.Set[RDFNode] = mutable.Set()
+      engine.setFocusNodeFilter(rdfNode => {
+        logger.debug(s"Checking focus node ${rdfNode}")
+        resourcesCheckedSet.add(rdfNode)
+        true
+      })
+
+      engine.validateAll()
+      val report = engine.getValidationReport
+
+      // Report on any nodes that were not checked.
+      val resourcesChecked: Set[RDFNode] = resourcesCheckedSet.toSet
+      val resourcesNotChecked: Seq[Resource] =
+        resourcesToCheck.filter(rdfNode => !resourcesChecked.contains(rdfNode))
+
+      /** Summarize a set of URIs as a string. */
+      def getShortenedURIs(nodes: Seq[Resource]): String = {
+        if (nodes.isEmpty) return "none"
+        else
+          return nodes
+              .map(node => {
+                // Try to use either the data model or the shape model to shorten URLs.
+                val dataModelQName   = dataModel.qnameFor(node.getURI)
+                val shapesModelQName = shapesModel.qnameFor(node.getURI)
+
+                if (dataModelQName != null) dataModelQName
+                else if (shapesModelQName != null) shapesModelQName
+                else node.getURI
+              })
+              .mkString(", ")
+      }
+
+      if (!resourcesNotChecked.isEmpty) {
+        val filteredResourcesNotChecked = resourcesNotChecked
+          .filter(rdfNode => {
+            // Filter out any RDF Nodes that appear to be well-formed rdf:List.
+            // This means they should have *both* rdf:first and rdf:rest.
+            val props = rdfNode.asResource.listProperties.toList.asScala.map(_.getPredicate).toSet
+
+            if (
+              props.size == 2 &&
+              (props contains RDF.first) &&
+              (props contains RDF.rest)
+            ) false
+            else true
+          })
+
+        filteredResourcesNotChecked
+          .foreach(rdfNode => {
+            val types =
+              rdfNode.asResource.listProperties(RDF.`type`).toList.asScala.map(_.getResource).toSeq
+            val props = rdfNode.asResource.listProperties.toList.asScala.map(_.getPredicate).toSeq
+            logger.warn(
+              s"Resource ${rdfNode} (types: ${getShortenedURIs(types)}; props: ${getShortenedURIs(props)}) was not checked."
+            )
+          })
+        logger.warn(f"${filteredResourcesNotChecked.size}%,d resources NOT checked.")
+      }
+      logger.info(f"${resourcesChecked.size}%,d resources checked.")
+
+      if (report.conforms) {
+        println(dataFile + " OK")
+        return true;
+      } else {
+        val errors = ValidationErrorGenerator.generate(report, shapesOntModel, dataModel)
+
+        def stringEndsWithOneOf(str: String, oneOf: Seq[String]): Boolean =
+          oneOf.exists(str.endsWith(_))
+
+        val filteredErrors = errors
+          .filter(
+            err =>
+              onlyConstraints.isEmpty || stringEndsWithOneOf(
+                err.sourceConstraintComponent.toString,
+                onlyConstraints
+              )
+          )
+          .filter(
+            err =>
+              ignoreConstraints.isEmpty || !stringEndsWithOneOf(
+                err.sourceConstraintComponent.toString,
+                ignoreConstraints
+              )
+          )
+
+        filteredErrors
+          .groupBy(_.classNode)
+          .foreach({
+            case (classNode, classErrors) =>
+              // TODO: look up the classNode label
+              println(s"CLASS <${classNode}> (${classErrors.length} errors)")
+              classErrors
+                .groupBy(_.focusNode)
+                .foreach({
+                  case (focusNode, focusErrors) =>
+                    println(s"Node ${focusNode} (${focusErrors.length} errors)")
+                    focusErrors
+                      .groupBy(_.path)
+                      .foreach({
+                        case (path, pathErrors) =>
+                          println(s" - Path <${path}> (${pathErrors.length} errors)")
+                          pathErrors.foreach(error => {
+                            println(
+                              s"   - [${error.sourceConstraintComponent}] ${error.message} ${error.value
+                                .map(value => s"(value: $value)")
+                                .mkString(", ")}"
+                            )
+                          })
+                          println()
+                      })
+                    println()
+                    if (conf.validate.displayNodes()) {
+                      // Display focusNode as Turtle.
+                      val focusNodeModel =
+                        focusNode.inModel(dataModel).asResource.listProperties.toModel
+                      focusNodeModel
+                        .setNsPrefixes(Map("SEPIO" -> "http://purl.obolibrary.org/obo/SEPIO_").asJava)
+
+                      val stringWriter = new StringWriter
+                      focusNodeModel.write(stringWriter, "Turtle")
+                      println(s"Focus node model:\n${stringWriter.toString}")
+                    }
+                })
+          })
+
+        println()
+        println(s"${filteredErrors.length} errors displayed")
+
+        val ignoredErrors = errors diff filteredErrors
+        if (!ignoredErrors.isEmpty) {
+          println(s"${ignoredErrors.length} errors ignored because:")
+          onlyConstraints.foreach(
+            only => println(s" - Only displaying sourceConstraintComponents ending in '$only'")
+          )
+          ignoreConstraints.foreach(
+            ignored => println(s" - Ignoring sourceConstraintComponents ending in '$ignored'")
+          )
+        }
+
+        println(dataFile + " FAILED VALIDATION")
+        return false;
+      }
+    }
+
+    if (dataFiles.map(checkDataFile(_)).forall(identity))
+      return 0
+    else
+      return 1
+  }
+}

--- a/src/main/scala/org/renci/shacli/validator/Validator.scala
+++ b/src/main/scala/org/renci/shacli/validator/Validator.scala
@@ -14,10 +14,8 @@ import org.topbraid.shacl.util.SHACLSystemModel
 import org.topbraid.shacl.vocabulary.SH
 import org.apache.jena.vocabulary.RDF
 import org.apache.jena.vocabulary.RDFS
-import org.rogach.scallop._
-import org.rogach.scallop.exceptions._
 
-import com.typesafe.scalalogging.{LazyLogging, Logger}
+import com.typesafe.scalalogging.Logger
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable

--- a/src/test/scala/org/renci/shacli/ShacliAppTest.scala
+++ b/src/test/scala/org/renci/shacli/ShacliAppTest.scala
@@ -41,7 +41,7 @@ object ShacliAppTest extends TestSuite {
       val test1shapes = new File(getClass.getResource("/test1_shapes.ttl").toURI)
       val test1data   = new File(getClass.getResource("/test1_data.ttl").toURI)
 
-      val res = exec(Seq("sbt", s"run $test1shapes $test1data"))
+      val res = exec(Seq("sbt", s"run validate $test1shapes $test1data"))
       assert(res.exitCode == 1)
       assert(res.stdout contains "Starting validation of")
       assert(res.stdout contains "Node http://example.org/Shadow (1 errors)")
@@ -68,7 +68,7 @@ object ShacliAppTest extends TestSuite {
       val test1shapes = new File(getClass.getResource("/test1_shapes.ttl").toURI)
       val test1data   = new File(getClass.getResource("/test1_data.jsonld").toURI)
 
-      val res = exec(Seq("sbt", s"run $test1shapes $test1data"))
+      val res = exec(Seq("sbt", s"run validate $test1shapes $test1data"))
       assert(res.exitCode == 1)
       assert(res.stdout contains "Starting validation of")
       assert(res.stdout contains "Node http://example.org/Shadow (1 errors)")
@@ -84,7 +84,7 @@ object ShacliAppTest extends TestSuite {
       val test1data_ttl    = new File(getClass.getResource("/test1_data.ttl").toURI)
       val test1data_jsonld = new File(getClass.getResource("/test1_data.jsonld").toURI)
 
-      val res = exec(Seq("sbt", s"run $test1shapes $test1data_ttl $test1data_jsonld"))
+      val res = exec(Seq("sbt", s"run validate $test1shapes $test1data_ttl $test1data_jsonld"))
       assert(res.exitCode == 1)
       assert(res.stdout contains "Starting validation of")
       assert(res.stdout contains "Node http://example.org/Shadow (1 errors)")

--- a/src/test/scala/org/renci/shacli/ShacliAppTest.scala
+++ b/src/test/scala/org/renci/shacli/ShacliAppTest.scala
@@ -53,7 +53,9 @@ object ShacliAppTest extends TestSuite {
       assert(res.stdout contains "Nonzero exit code returned from runner: 1")
 
       // Make sure we detect that the list in Buck foaf:depiction is broken.
-      assert(res.stdout contains "[http://www.w3.org/ns/shacl#NodeConstraintComponent] Value does not have shape dash:ListShape")
+      assert(
+        res.stdout contains "[http://www.w3.org/ns/shacl#NodeConstraintComponent] Value does not have shape dash:ListShape"
+      )
 
       // Additionally, we should provide a warning: there is a resource in the
       // Turtle file (example:CheshireCat) that was not validated.
@@ -91,7 +93,9 @@ object ShacliAppTest extends TestSuite {
 
       // Make sure we detect that the list in Buck foaf:depiction is broken.
       assert(res.stdout contains "Node http://example.org/Buck (1 errors)")
-      assert(res.stdout contains "[http://www.w3.org/ns/shacl#NodeConstraintComponent] Value does not have shape dash:ListShape")
+      assert(
+        res.stdout contains "[http://www.w3.org/ns/shacl#NodeConstraintComponent] Value does not have shape dash:ListShape"
+      )
 
       assert(
         res.stdout contains "- [http://www.w3.org/ns/shacl#MaxCountConstraintComponent] Property may only have 1 value, but found 2"


### PR DESCRIPTION
This PR separates validation into a separate package, invocable with its own subcommand. This is better for organization, and allows us to implement additional subcommands as needed. It also creates a blank package for generation, which I'll fill in on a separate PR.