### PR TITLE
Generate SHACL for given RDF data

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ licenses := Seq("MIT" -> url("https://opensource.org/licenses/MIT"))
 
 // Scalac options.
 scalaVersion := "2.12.10"
-scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8", "-Ywarn-unused")
+scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8", "-Ywarn-unused", "-feature")
 
 addCompilerPlugin(scalafixSemanticdb)
 scalacOptions in Test ++= Seq("-Yrangepos")

--- a/src/main/scala/org/renci/shacli/ShacliApp.scala
+++ b/src/main/scala/org/renci/shacli/ShacliApp.scala
@@ -2,15 +2,11 @@ package org.renci.shacli
 
 import java.io.File
 
-import java.io.File
-
+import com.typesafe.scalalogging.{LazyLogging, Logger}
+import org.renci.shacli.generator.Generator
+import org.renci.shacli.validator.Validator
 import org.rogach.scallop._
 import org.rogach.scallop.exceptions._
-
-import com.typesafe.scalalogging.{LazyLogging, Logger}
-
-import org.renci.shacli.validator.Validator
-import org.renci.shacli.generator.Generator
 
 /**
   * Use the given shapes file to validate the given data file.
@@ -18,6 +14,7 @@ import org.renci.shacli.generator.Generator
   * TopBraid's SHACL engine.
   */
 object ShacliApp extends App with LazyLogging {
+
   /**
     * Command line configuration for Validate.
     */
@@ -30,7 +27,7 @@ object ShacliApp extends App with LazyLogging {
       case ex => super.onError(ex)
     }
 
-    val version = getClass.getPackage.getImplementationVersion
+    val version: String = getClass.getPackage.getImplementationVersion
     version("SHACLI: A SHACLI CLI v" + version)
     val validate: validate = new validate
     class validate extends Subcommand("validate") {
@@ -62,6 +59,11 @@ object ShacliApp extends App with LazyLogging {
       val baseURI: ScallopOption[String] = opt[String](
         descr = "Base URI of the shapes to generate",
         default = Some("http://example.org/")
+      )
+      val reasoning: ScallopOption[String] = opt[String](
+        descr = "Choose reasoning: none (default), rdfs or owl",
+        default = Some("none")
+        // TODO: add validation to ensure that its one of the three kinds.
       )
     }
     addSubcommand(generate)

--- a/src/main/scala/org/renci/shacli/ShacliApp.scala
+++ b/src/main/scala/org/renci/shacli/ShacliApp.scala
@@ -56,7 +56,7 @@ object ShacliApp extends App with LazyLogging {
     val generate: generate = new generate
     class generate extends Subcommand("generate") {
       val data: ScallopOption[List[File]] =
-        trailArg[List[File]](descr = "Data file(s) to validate (in Turtle)")
+        trailArg[List[File]](descr = "Data file(s) or directories to validate (in Turtle)")
     }
     addSubcommand(generate)
 

--- a/src/main/scala/org/renci/shacli/ShacliApp.scala
+++ b/src/main/scala/org/renci/shacli/ShacliApp.scala
@@ -57,6 +57,12 @@ object ShacliApp extends App with LazyLogging {
     class generate extends Subcommand("generate") {
       val data: ScallopOption[List[File]] =
         trailArg[List[File]](descr = "Data file(s) or directories to validate (in Turtle)")
+      val output: ScallopOption[String] =
+        opt[String](descr = "Output file where SHACL should be written", default = Some("-"))
+      val baseURI: ScallopOption[String] = opt[String](
+        descr = "Base URI of the shapes to generate",
+        default = Some("http://example.org/")
+      )
     }
     addSubcommand(generate)
 

--- a/src/main/scala/org/renci/shacli/generator/Generator.scala
+++ b/src/main/scala/org/renci/shacli/generator/Generator.scala
@@ -1,6 +1,15 @@
 package org.renci.shacli.generator
 
+import scala.language.reflectiveCalls
+import scala.collection.JavaConverters._
+
+import java.io.{File, BufferedOutputStream, FileOutputStream}
+
 import com.typesafe.scalalogging.Logger
+import org.apache.jena.rdf.model.{Model, InfModel, ModelFactory}
+import org.apache.jena.riot.{RDFDataMgr, RDFFormat}
+import org.apache.jena.vocabulary.RDF
+import org.topbraid.shacl.vocabulary.SH
 
 import org.renci.shacli.ShacliApp
 
@@ -9,7 +18,64 @@ import org.renci.shacli.ShacliApp
   */
 object Generator {
   def generate(logger: Logger, conf: ShacliApp.Conf): Int = {
-    println("Generate with conf: " + conf)
+    val dataFiles: List[File]  = conf.generate.data()
+    val baseURI: String        = conf.generate.baseURI()
+    val outputFilename: String = conf.generate.output()
+
+    // Start by loading all data into a single data model.
+    val dataModel: Model = ModelFactory.createDefaultModel
+    dataFiles
+      .flatMap(fileOrDir => {
+        if (fileOrDir.isDirectory) fileOrDir.listFiles
+        else Seq(fileOrDir)
+      })
+      .foreach(dataFile => {
+        logger.info("Reading " + dataFile)
+        dataModel.add(RDFDataMgr.loadModel(dataFile.toString))
+      })
+    val infModel: InfModel = ModelFactory.createRDFSModel(dataModel)
+
+    // Identify every rdf:type in this data model.
+    val typedResources = infModel.listResourcesWithProperty(RDF.`type`).toList.asScala.toSeq
+    val resProps = typedResources
+      .flatMap(res => res.listProperties(RDF.`type`).toList.asScala)
+      .groupBy(_.getObject)
+      .mapValues(_.map(_.getSubject))
+
+    logger.info(s"Found ${resProps.size} resources belonging to ${resProps.keySet.size} types.")
+
+    val shapesModel = ModelFactory.createDefaultModel
+    shapesModel.setNsPrefixes(dataModel)
+    shapesModel.setNsPrefix("", baseURI)
+    shapesModel.setNsPrefix("shacl", SH.getURI)
+
+    resProps.keys.foreach(rdfClass => {
+      println("Class " + dataModel.shortForm(rdfClass.asResource.getURI))
+
+      val shapeResource =
+        shapesModel.createResource(baseURI + rdfClass.asResource.getLocalName + "Shape")
+      shapeResource.addProperty(RDF.`type`, SH.NodeShape)
+      shapeResource.addProperty(SH.targetClass, rdfClass)
+
+      val props = resProps
+        .getOrElse(rdfClass, Seq())
+        .flatMap(_.listProperties.toList.asScala.map(_.getPredicate))
+        .toSet
+      props.foreach(prop => {
+        println(" - Property: " + dataModel.shortForm(prop.getURI))
+      })
+    })
+
+    // Choose output file.
+    val outputStream =
+      if (outputFilename == "-") System.out
+      else
+        new BufferedOutputStream(new FileOutputStream(new File(outputFilename)))
+
+    RDFDataMgr.write(outputStream, shapesModel, RDFFormat.TURTLE_PRETTY)
+
+    if (outputFilename != "-") outputStream.close
+
     return 0
   }
 }

--- a/src/main/scala/org/renci/shacli/generator/Generator.scala
+++ b/src/main/scala/org/renci/shacli/generator/Generator.scala
@@ -1,25 +1,24 @@
 package org.renci.shacli.generator
 
-import scala.language.reflectiveCalls
-import scala.collection.JavaConverters._
-
-import java.io.{File, BufferedOutputStream, FileOutputStream}
+import java.io.{BufferedOutputStream, File, FileOutputStream}
 
 import com.typesafe.scalalogging.Logger
-import org.apache.jena.rdf.model.{Model, InfModel, ModelFactory}
+import org.apache.jena.rdf.model.{InfModel, Model, ModelFactory, RDFNode, Resource}
 import org.apache.jena.riot.{RDFDataMgr, RDFFormat}
-import org.apache.jena.vocabulary.RDF
+import org.apache.jena.vocabulary.{RDF, RDFS}
+import org.renci.shacli.ShacliApp
 import org.topbraid.shacl.vocabulary.SH
 
-import org.renci.shacli.ShacliApp
+import scala.collection.JavaConverters._
+import scala.language.reflectiveCalls
 
 /**
   * Generate SHACL based on Turtle provided.
   */
 object Generator {
   def generate(logger: Logger, conf: ShacliApp.Conf): Int = {
-    val dataFiles: List[File]  = conf.generate.data()
-    val baseURI: String        = conf.generate.baseURI()
+    val dataFiles: List[File] = conf.generate.data()
+    val baseURI: String = conf.generate.baseURI()
     val outputFilename: String = conf.generate.output()
 
     // Start by loading all data into a single data model.
@@ -36,8 +35,8 @@ object Generator {
     val infModel: InfModel = ModelFactory.createRDFSModel(dataModel)
 
     // Identify every rdf:type in this data model.
-    val typedResources = infModel.listResourcesWithProperty(RDF.`type`).toList.asScala.toSeq
-    val resProps = typedResources
+    val typedResources = infModel.listResourcesWithProperty(RDF.`type`).toList.asScala
+    val resProps: Map[RDFNode, Seq[Resource]] = typedResources
       .flatMap(res => res.listProperties(RDF.`type`).toList.asScala)
       .groupBy(_.getObject)
       .mapValues(_.map(_.getSubject))
@@ -52,17 +51,59 @@ object Generator {
     resProps.keys.foreach(rdfClass => {
       println("Class " + dataModel.shortForm(rdfClass.asResource.getURI))
 
-      val shapeResource =
+      val shapeRes =
         shapesModel.createResource(baseURI + rdfClass.asResource.getLocalName + "Shape")
-      shapeResource.addProperty(RDF.`type`, SH.NodeShape)
-      shapeResource.addProperty(SH.targetClass, rdfClass)
+      shapeRes.addProperty(RDF.`type`, SH.NodeShape)
+      shapeRes.addProperty(SH.targetClass, rdfClass)
 
       val props = resProps
         .getOrElse(rdfClass, Seq())
         .flatMap(_.listProperties.toList.asScala.map(_.getPredicate))
         .toSet
+
       props.foreach(prop => {
-        println(" - Property: " + dataModel.shortForm(prop.getURI))
+        // Set up the shacl:path.
+        val propRes = shapesModel.createResource()
+        propRes.addProperty(
+          SH.path,
+          prop
+        )
+
+        // Find names and descriptions for this property.
+        val labels = prop.listProperties(RDFS.label).toList.asScala.map(_.getLiteral)
+        labels.foreach(literal => propRes.addProperty(
+          SH.name,
+          literal
+        ))
+
+        // Find a description for this property.
+        propRes.addProperty(
+          SH.description,
+          "Enter description here"
+        )
+
+        // What is the minimum and maximum number of times this property is used
+        // per entity?
+        val resourcesInType = resProps.getOrElse(rdfClass, Seq())
+        val propCountPerResource = resourcesInType.map(_.listProperties(prop).toList.size)
+
+        val minCount: Long = propCountPerResource.min
+        val maxCount: Long = propCountPerResource.max
+
+        propRes.addLiteral(
+          SH.minCount,
+          minCount
+        )
+
+        propRes.addLiteral(
+          SH.maxCount,
+          maxCount
+        )
+
+        shapeRes.addProperty(SH.property, propRes)
+
+        // Report
+        println(s" - Property: ${dataModel.shortForm(prop.getURI)} (min: $minCount, max: $maxCount)")
       })
     })
 
@@ -74,8 +115,8 @@ object Generator {
 
     RDFDataMgr.write(outputStream, shapesModel, RDFFormat.TURTLE_PRETTY)
 
-    if (outputFilename != "-") outputStream.close
+    if (outputFilename != "-") outputStream.close()
 
-    return 0
+    0
   }
 }

--- a/src/main/scala/org/renci/shacli/validator/Validator.scala
+++ b/src/main/scala/org/renci/shacli/validator/Validator.scala
@@ -1,7 +1,10 @@
 package org.renci.shacli.validator
 
-import java.io.File
+import scala.language.reflectiveCalls
+import scala.collection.JavaConverters._
+import scala.collection.mutable
 
+import java.io.File
 import java.io.{InputStream, File, ByteArrayOutputStream, StringWriter}
 
 import org.topbraid.shacl.validation._
@@ -14,11 +17,7 @@ import org.topbraid.shacl.util.SHACLSystemModel
 import org.topbraid.shacl.vocabulary.SH
 import org.apache.jena.vocabulary.RDF
 import org.apache.jena.vocabulary.RDFS
-
 import com.typesafe.scalalogging.Logger
-
-import scala.collection.JavaConverters._
-import scala.collection.mutable
 
 import org.renci.shacli.ShacliApp
 


### PR DESCRIPTION
This PR adds a new `generate` option, which allows SHACLI to generate SHACL shapes for input RDF data. It guesses the datatype, nodeKind, minCount and maxCount based on the properties in the input data, and adds a `sh:Description` field for you to fill in. The produced SHACL is not intended to be used immediately, but to be edited into a complete set of SHACL shapes.

I'll merge this in for now, since it rearranges SHACLI's code and command-line syntax somewhat, but adding tests will be covered by #16.