### PR TITLE
Publish v0.1 to OSSRH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2020-04-14
+- Includes a Validator that can be used to validate RDF data against SHACL files.
+  - Also includes tests for the validator.
+- Includes a Generator that can be used to generate SHACL shapes for input RDF data.
+  - No tests have yet been written for the generator.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2020 Gaurav Vaidya (RENCI)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SHACLI: A SHACLI CLI
 
+[![Build Status](https://travis-ci.org/gaurav/shacli.svg?branch=master)](https://travis-ci.org/gaurav/shacli)
+
 `shacli` is a command-line interface to the [Shapes Constraint Language (SHACL)](https://www.w3.org/TR/shacl/).
 It was originally developed as part of the effort to convert the [ClinGen Interpretation Model to SHACL](https://github.com/clingen-data-model/spec2shacl),
 where we needed a tool that provided clear error messages to anyone using SHACL to validate incoming data.

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 // Publication information
 name := "Shacli"
 ThisBuild / organization := "org.shacli"
-ThisBuild / version      := "0.1-SNAPSHOT"
+ThisBuild / version      := "0.1"
 
 // Code license
 licenses := Seq("MIT" -> url("https://opensource.org/licenses/MIT"))

--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,11 @@ addCommandAlias(
 // Publish to Sonotype OSSRH.
 publishTo := sonatypePublishToBundle.value
 
+addCommandAlias(
+  "publishToSonatype",
+  "; publishSigned; sonatypeBundleRelease"
+)
+
 // Library dependencies.
 libraryDependencies ++= {
   Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 // Publication information
-name := "shacli"
-ThisBuild / organization := "com.ggvaidya"
+name := "Shacli"
+ThisBuild / organization := "org.shacli"
 ThisBuild / version      := "0.1-SNAPSHOT"
 
 // Code license
@@ -29,6 +29,9 @@ addCommandAlias(
   "scalafixCheckAll",
   "; compile:scalafix --check ; test:scalafix --check"
 )
+
+// Publish to Sonotype OSSRH.
+publishTo := sonatypePublishToBundle.value
 
 // Library dependencies.
 libraryDependencies ++= {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,3 +2,7 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.1")
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.3")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.11")
+
+// Publishing to Sonotype OSSRH.
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.2")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,0 +1,24 @@
+// Your profile name of the sonatype account. The default is the same with the organization value
+sonatypeProfileName := "org.shacli"
+
+// To sync with Maven central, you need to supply the following information:
+publishMavenStyle := true
+
+// Open-source license of your choice
+licenses := Seq("MIT" -> url("https://opensource.org/licenses/MIT"))
+
+// Where is the source code hosted: GitHub or GitLab?
+import xerial.sbt.Sonatype._
+sonatypeProjectHosting := Some(GitHubHosting("gaurav", "shacli", "gaurav@ggvaidya.com"))
+
+// or if you want to set these fields manually
+homepage := Some(url("https://shacli.org"))
+scmInfo := Some(
+  ScmInfo(
+    url("https://github.com/gaurav/shacli"),
+    "scm:git@github.com:gaurav/shacli.git"
+  )
+)
+developers := List(
+  Developer(id="gaurav", name="Gaurav Vaidya", email="gaurav@ggvaidya.com", url=url("http://ggvaidya.com"))
+)


### PR DESCRIPTION
This PR creates a v0.1.0 of the software has the minimum requirements to be published to [Sonatype OSSRH](https://central.sonatype.org/pages/ossrh-guide.html). It includes:
 - SBT plugins to facilitate the upload and publication of this package.
 - Changes the organization of the package to `org.shacli` and the package name to `Shacli`.
 - Addition of a software license, CHANGELOG and a build status in the README file.

Closes #9.