### PR TITLE
Improve error output

### DIFF
--- a/src/main/scala/org/renci/shacli/validator/Validator.scala
+++ b/src/main/scala/org/renci/shacli/validator/Validator.scala
@@ -239,27 +239,29 @@ object Validator {
           if (statement != null) s" (${statement.getString})" else ""
         }
 
+        def errorCountWithLeadingSpace(errorCount: Int): String = if (errorCount == 1) "" else s" ($errorCount errors)"
+
         filteredErrors
           .groupBy(_.classNode)
           .foreach({
             case (classNode, classErrors) =>
               // TODO: look up the classNode label
-              println(s"CLASS <${classNode}>${getLabelWithLeadingSpace(classNode)} (${classErrors.length} errors)")
+              println(s"CLASS <${classNode}>${getLabelWithLeadingSpace(classNode)}${errorCountWithLeadingSpace(classErrors.length)}")
               classErrors
                 .groupBy(_.focusNode)
                 .foreach({
                   case (focusNode, focusErrors) =>
-                    println(s"Node ${focusNode}${getLabelWithLeadingSpace(focusNode)} (${focusErrors.length} errors)")
+                    println(s"Node ${focusNode}${getLabelWithLeadingSpace(focusNode)}${errorCountWithLeadingSpace(focusErrors.length)}")
                     focusErrors
                       .groupBy(_.path)
                       .foreach({
                         case (path, pathErrors) =>
-                          println(s" - Path <${path}>${getLabelWithLeadingSpace(dataModel.getResource(path))} (${pathErrors.length} errors)")
+                          println(s" - Path <${path}>${getLabelWithLeadingSpace(dataModel.getResource(path))}${errorCountWithLeadingSpace(pathErrors.length)}")
                           pathErrors.foreach(error => {
                             println(
-                              s"   - [${error.sourceConstraintComponent}] ${error.message} ${error.value
-                                .map(value => s"(value: $value)")
-                                .mkString(", ")}"
+                              s"   - [${error.sourceConstraintComponent}] ${error.message}.${error.value
+                                .map(value => s"\n     - Value: $value${getLabelWithLeadingSpace(value)}")
+                                .mkString("")}"
                             )
                           })
                           println()

--- a/src/main/scala/org/renci/shacli/validator/Validator.scala
+++ b/src/main/scala/org/renci/shacli/validator/Validator.scala
@@ -261,14 +261,13 @@ object Validator {
                       // Display focusNode as Turtle.
                       val focusNodeModel =
                         focusNode.inModel(dataModel).asResource.listProperties.toModel
-                      focusNodeModel
-                        .setNsPrefixes(
-                          Map("SEPIO" -> "http://purl.obolibrary.org/obo/SEPIO_").asJava
-                        )
+                      focusNodeModel.setNsPrefixes(shapesModel)
+                      focusNodeModel.setNsPrefixes(dataModel)
 
                       val stringWriter = new StringWriter
                       focusNodeModel.write(stringWriter, "Turtle")
-                      println(s"Focus node model:\n${stringWriter.toString}")
+
+                      println(s"Focus node model:\n${stringWriter.toString}\n")
                     }
                 })
           })

--- a/src/test/scala/org/renci/shacli/ShacliAppTest.scala
+++ b/src/test/scala/org/renci/shacli/ShacliAppTest.scala
@@ -44,8 +44,8 @@ object ShacliAppTest extends TestSuite {
       val res = exec(Seq("sbt", s"run validate $test1shapes $test1data"))
       assert(res.exitCode == 1)
       assert(res.stdout contains "Starting validation of")
-      assert(res.stdout contains "Node http://example.org/Shadow (1 errors)")
-      assert(res.stdout contains "Node http://example.org/Buck (1 errors)")
+      assert(res.stdout contains "Node http://example.org/Shadow")
+      assert(res.stdout contains "Node http://example.org/Buck")
       assert(
         res.stdout contains "- [http://www.w3.org/ns/shacl#MaxCountConstraintComponent] Property may only have 1 value, but found 2"
       )
@@ -73,7 +73,7 @@ object ShacliAppTest extends TestSuite {
       val res = exec(Seq("sbt", s"run validate $test1shapes $test1data"))
       assert(res.exitCode == 1)
       assert(res.stdout contains "Starting validation of")
-      assert(res.stdout contains "Node http://example.org/Shadow (1 errors)")
+      assert(res.stdout contains "Node http://example.org/Shadow")
       assert(
         res.stdout contains "- [http://www.w3.org/ns/shacl#MaxCountConstraintComponent] Property may only have 1 value, but found 2"
       )
@@ -89,10 +89,10 @@ object ShacliAppTest extends TestSuite {
       val res = exec(Seq("sbt", s"run validate $test1shapes $test1data_ttl $test1data_jsonld"))
       assert(res.exitCode == 1)
       assert(res.stdout contains "Starting validation of")
-      assert(res.stdout contains "Node http://example.org/Shadow (1 errors)")
+      assert(res.stdout contains "Node http://example.org/Shadow")
 
       // Make sure we detect that the list in Buck foaf:depiction is broken.
-      assert(res.stdout contains "Node http://example.org/Buck (1 errors)")
+      assert(res.stdout contains "Node http://example.org/Buck")
       assert(
         res.stdout contains "[http://www.w3.org/ns/shacl#NodeConstraintComponent] Value does not have shape dash:ListShape"
       )


### PR DESCRIPTION
This PR includes improvements to the outputs of SHACLI by:
 - Not displaying "(1 errors)" unless there are more than one errors.
 - Improved display of RDF Nodes that have labels.
 - Display the value nodes as well as the focus nodes for each error.