### PR TITLE
Add additional options for validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] 
+- Added support for reasoning, summarizing errors and import of additional data.
 
 ## [0.1] - 2020-04-14
 - Includes a Validator that can be used to validate RDF data against SHACL files.

--- a/src/main/scala/org/renci/shacli/ShacliApp.scala
+++ b/src/main/scala/org/renci/shacli/ShacliApp.scala
@@ -43,6 +43,10 @@ object ShacliApp extends App with LazyLogging {
         default = Some(List()),
         descr = "Don't display SourceConstraintComponent ending with these strings"
       )
+      val `import`: ScallopOption[List[String]] = opt[List[String]](
+        descr = "Import URIs or files into the data model before processing",
+        default = Some(List.empty)
+      )
       val displayNodes: ScallopOption[Boolean] =
         opt[Boolean](default = Some(false), descr = "Display all failing nodes as Turtle")
       val summarizeErrors: ScallopOption[Boolean] = opt[Boolean](

--- a/src/main/scala/org/renci/shacli/ShacliApp.scala
+++ b/src/main/scala/org/renci/shacli/ShacliApp.scala
@@ -45,6 +45,10 @@ object ShacliApp extends App with LazyLogging {
       )
       val displayNodes: ScallopOption[Boolean] =
         opt[Boolean](default = Some(false), descr = "Display all failing nodes as Turtle")
+      val summarizeErrors: ScallopOption[Boolean] = opt[Boolean](
+        default = Some(true),
+        descr = "Summarize the validation errors seen"
+      )
     }
     addSubcommand(validate)
 

--- a/src/main/scala/org/renci/shacli/ShacliApp.scala
+++ b/src/main/scala/org/renci/shacli/ShacliApp.scala
@@ -49,6 +49,11 @@ object ShacliApp extends App with LazyLogging {
         default = Some(true),
         descr = "Summarize the validation errors seen"
       )
+      val reasoning: ScallopOption[String] = opt[String](
+        descr = "Choose reasoning: none (default), rdfs or owl",
+        default = Some("none"),
+        validate = Set("none", "rdfs", "owl").contains(_)
+      )
     }
     addSubcommand(validate)
 
@@ -66,8 +71,8 @@ object ShacliApp extends App with LazyLogging {
       )
       val reasoning: ScallopOption[String] = opt[String](
         descr = "Choose reasoning: none (default), rdfs or owl",
-        default = Some("none")
-        // TODO: add validation to ensure that its one of the three kinds.
+        default = Some("none"),
+        validate = Set("none", "rdfs", "owl").contains(_)
       )
     }
     addSubcommand(generate)

--- a/src/main/scala/org/renci/shacli/validator/Validator.scala
+++ b/src/main/scala/org/renci/shacli/validator/Validator.scala
@@ -3,13 +3,12 @@ package org.renci.shacli.validator
 import scala.language.reflectiveCalls
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-
-import java.io.File
-import java.io.{InputStream, File, ByteArrayOutputStream, StringWriter}
+import java.net.URI
+import java.io.{ByteArrayOutputStream, File, InputStream, StringWriter}
 
 import org.topbraid.shacl.validation._
 import org.apache.jena.ontology.{OntModel, OntModelSpec}
-import org.apache.jena.rdf.model.{Model, ModelFactory, Resource, RDFNode, RDFList}
+import org.apache.jena.rdf.model.{Model, ModelFactory, RDFList, RDFNode, Resource}
 import org.apache.jena.riot.RDFDataMgr
 import org.apache.jena.util.FileUtils
 import org.topbraid.jenax.util.SystemTriples
@@ -18,7 +17,6 @@ import org.topbraid.shacl.vocabulary.SH
 import org.apache.jena.vocabulary.RDF
 import org.apache.jena.vocabulary.RDFS
 import com.typesafe.scalalogging.Logger
-
 import org.renci.shacli.ShacliApp
 
 /*
@@ -133,6 +131,13 @@ object Validator {
       // Load the data model.
       val loadedModel: Model = RDFDataMgr.loadModel(dataFile.toString);
 
+      conf.validate.`import`().foreach(toImport => {
+        try {
+          RDFDataMgr.read(loadedModel, toImport)
+        } catch {
+          case exception: Exception => logger.error(s"Could not load $toImport: $exception")
+        }
+      })
 
       // Turn on reasoning.
       val dataModel: Model = conf.validate.reasoning() match {

--- a/src/main/scala/org/renci/shacli/validator/Validator.scala
+++ b/src/main/scala/org/renci/shacli/validator/Validator.scala
@@ -314,6 +314,18 @@ object Validator {
           )
         }
 
+        if(conf.validate.summarizeErrors()) {
+          println("Validation errors discovered:")
+          val errorsByConstraint = filteredErrors.groupBy(_.sourceConstraintComponent)
+          errorsByConstraint.keySet.toSeq.sorted(new Ordering[Resource]() {
+            override def compare(x: Resource, y: Resource): Int = x.getLocalName.compareTo(y.getLocalName)
+          }).map(constraint => {
+            val errors = errorsByConstraint.getOrElse(constraint, Seq())
+            println(s" - ${getShortenedURIs(Seq(constraint))}: ${errors.size} errors")
+          })
+          println()
+        }
+
         println(dataFile + " FAILED VALIDATION")
         return false;
       }

--- a/src/main/scala/org/renci/shacli/validator/Validator.scala
+++ b/src/main/scala/org/renci/shacli/validator/Validator.scala
@@ -131,7 +131,15 @@ object Validator {
       logger.info(s"Starting validation of $dataFile against $shapesFile.")
 
       // Load the data model.
-      val dataModel: Model                = RDFDataMgr.loadModel(dataFile.toString);
+      val loadedModel: Model = RDFDataMgr.loadModel(dataFile.toString);
+
+
+      // Turn on reasoning.
+      val dataModel: Model = conf.validate.reasoning() match {
+        case "none" => loadedModel
+        case "rdfs" => ModelFactory.createRDFSModel(loadedModel)
+        case "owl" => ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM, loadedModel)
+      }
       val resourcesToCheck: Seq[Resource] = dataModel.listSubjects.toList.asScala
       logger.debug(s"Resources to check: ${resourcesToCheck}")
 


### PR DESCRIPTION
These options are:
- `--reasoning`: Turns on either reasoning RDFS or OWL reasoning.
- `--summarize-errors`: Can be used turn on or off the summarized errors at the end of the output.
- `--import`: Indicates RDF data that should be included. Useful for loading prefixes to be used in the error output.